### PR TITLE
fix invalid variable name of keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Running [Calcit Editor](https://github.com/Cirru/calcit-editor#compact-output) with `compact=true caclcit-editor` enables compact mode,
 which writes `compact.cirru` and `.compact-inc.cirru` instead of Clojure(Script).
-And this project provides a runner for `compact.cirru`, written on Nim for low overhead.
+And this project provides a runner for `compact.cirru`, written on Rust for low overhead.
 
 A `compact.cirru` file can be:
 
@@ -49,8 +49,9 @@ calcit_runner -e="range 100" # eval from CLI
 calcit_runner compact.cirru --emit-js # compile to js
 calcit_runner compact.cirru --emit-js --emit-path=out/ # compile to js and save in `out/`
 
+calcit_runner compact.cirru --emit-ir # compiles intermediate representation into program-ir.json
+
 calcit_runner compact.cirru --emit-js --mjs # TODO compile to mjs
-calcit_runner compact.cirru --emit-ir # TODO compile to intermediate representation
 ```
 
 For linux users, download pre-built binaries from http://bin.calcit-lang.org/linux/ .
@@ -69,7 +70,7 @@ For linux users, download pre-built binaries from http://bin.calcit-lang.org/lin
 
 Calcit Runner use `~/.config/calcit/modules/` as modules directory.
 Paths defined in `:modules` field are just loaded as files based on this directory,
-which is: `~/.config/calcit/modules/phlox.caclit.nim/compact.cirru`.
+which is: `~/.config/calcit/modules/phlox/compact.cirru`.
 
 To load modules in CI environment, create that folder and clone repos manually.
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1088,15 +1088,15 @@
               , s
 
         |select-keys $ quote
-          defn select-keys (m keys)
+          defn select-keys (m xs)
             assert "|expectd map for selecting" $ map? m
-            foldl keys (&{}) $ fn (acc k)
+            foldl xs (&{}) $ fn (acc k)
               assoc acc k (&get m k)
 
         |unselect-keys $ quote
-          defn unselect-keys (m keys)
+          defn unselect-keys (m xs)
             assert "|expectd map for unselecting" $ map? m
-            foldl keys m $ fn (acc k)
+            foldl xs m $ fn (acc k)
               dissoc acc k
 
         |conj $ quote


### PR DESCRIPTION
`keys` shadows core definition `keys`... bad name.
