### PR TITLE
partial refactor on import rules to support :default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.16"
+version = "0.3.17"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.0.1",

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use crate::primes::{Calcit, CalcitItems, SymbolResolved::*};
+use crate::primes::{Calcit, CalcitItems, ImportRule, SymbolResolved::*};
 use crate::program;
 
 #[derive(Serialize, Deserialize)]
@@ -90,10 +90,16 @@ fn dump_code(code: &Calcit) -> serde_json::Value {
       "val": s,
       "ns": ns,
       "resolved": match resolved {
-        Some(ResolvedDef(r_def, r_ns)) => json!({
+        Some(ResolvedDef(r_def, r_ns, import_rule)) => json!({
           "kind": "def",
           "ns": r_ns,
           "def": r_def,
+          "rule": match import_rule {
+            Some(ImportRule::NsAs(_n)) => json!("ns"),
+            Some(ImportRule::NsDefault(_n)) => json!("default"),
+            Some(ImportRule::NsReferDef(_ns, _def)) => json!("def"),
+            None => serde_json::Value::Null,
+          }
         }),
         Some(ResolvedLocal) => json!({
           "kind": "local"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub fn run_program(init_fn: &str, params: CalcitItems, program_code: &program::P
 
   let (init_ns, init_def) = util::string::extract_ns_def(init_fn)?;
   // preprocess to init
-  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &program_code, &init_def) {
+  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &program_code, &init_def, None) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn run_codegen(
   }
 
   // preprocess to init
-  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &program_code, &init_def) {
+  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &program_code, &init_def, None) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);
@@ -191,7 +191,7 @@ fn run_codegen(
   }
 
   // preprocess to reload
-  match runner::preprocess::preprocess_ns_def(&reload_ns, &reload_def, &program_code, &init_def) {
+  match runner::preprocess::preprocess_ns_def(&reload_ns, &reload_def, &program_code, &init_def, None) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -16,8 +16,16 @@ pub type CalcitItems = im::Vector<Calcit>;
 #[derive(Debug, Clone, PartialEq)]
 pub enum SymbolResolved {
   ResolvedLocal,
-  ResolvedRaw,                 // raw syntax, no target
-  ResolvedDef(String, String), // ns, def
+  ResolvedRaw,                                     // raw syntax, no target
+  ResolvedDef(String, String, Option<ImportRule>), // ns, def
+}
+
+/// defRule: ns def
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportRule {
+  NsAs(String),               // ns
+  NsReferDef(String, String), // ns, def
+  NsDefault(String),          // ns, js only
 }
 
 /// special types wraps vector of calcit data for displaying

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -22,7 +22,7 @@ pub fn evaluate_expr(
     Calcit::Number(_) => Ok(expr.clone()),
     Calcit::Symbol(s, ..) if s == "&" => Ok(expr.clone()),
     Calcit::Symbol(s, ns, resolved) => match resolved {
-      Some(ResolvedDef(r_ns, r_def)) => {
+      Some(ResolvedDef(r_ns, r_def, _import_rule)) => {
         let v = evaluate_symbol(&r_def, scope, &r_ns, program_code)?;
         match v {
           // extra check to make sure thunks extracted


### PR DESCRIPTION
After this change:

```cirru
  :require
    |dayjs :default dayjs
```

generates:

```js
import dayjs from "dayjs";
```

And previous `dayjs/@` has been removed.