### PR TITLE
add invoke; fix duplication evaluation of thunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.19"
+version = "0.3.20"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -223,6 +223,25 @@
             assert= 2 @*ref-demo
             assert= :ref (type-of *ref-demo)
 
+        |%Num $ quote
+          defrecord %Num :inc :show
+        |Num $ quote
+          def Num $ %{} %Num
+            :inc $ fn (x) $ [] Num (&+ x 1)
+            :show $ fn (x) $ str x
+
+        |test-invoke $ quote
+          fn ()
+            log-title "|Testing invoke"
+
+            let
+                a $ [] Num 0
+              assert=
+                [] Num 2
+                -> a (invoke :inc) (invoke :inc)
+              assert= |1
+                -> a (invoke :inc) (invoke :show)
+
         |reload! $ quote
           defn reload! () nil
 
@@ -257,6 +276,8 @@
             test-fn-eq
 
             test-refs
+            
+            test-invoke
 
             inside-eval:
               test-gynienic/main!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.0.1",

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -46,6 +46,7 @@ pub fn turn_string(xs: &CalcitItems) -> Result<Calcit, String> {
     Some(Calcit::Str(s)) => Ok(Calcit::Str(s.clone())),
     Some(Calcit::Keyword(s)) => Ok(Calcit::Str(s.clone())),
     Some(Calcit::Symbol(s, ..)) => Ok(Calcit::Str(s.clone())),
+    Some(Calcit::Number(n)) => Ok(Calcit::Str(n.to_string())),
     Some(a) => Err(format!("turn-string cannot turn this to string: {}", a)),
     None => Err(String::from("turn-string expected 1 argument, got nothing")),
   }

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1115,3 +1115,15 @@
 
         |/= $ quote
           defn /= (a b) (not= a b)
+
+        |invoke $ quote
+          defn invoke (pair name & params)
+            assert "|method! applies on a pair, leading a record"
+              and (list? pair) (= 2 (count pair)) (record? (first pair))
+            assert "|method by string or keyword"
+              or (string? name) (keyword? name) (symbol? name)
+            let
+                proto $ nth pair 0
+                f $ &get proto name
+              assert "|expected function" (fn? f)
+              f (nth pair 1) & params


### PR DESCRIPTION
With `invoke`, we can now simulate ad-hoc polymorphism(in a very slow way...) in a dynamic manner. However, with this function, we don't have to implement a language-level ad-hoc polymorphism to make this Lisp really complicated.

Implementation of `invoke`:

```cirru
defn invoke (pair name & params)
  assert "|method! applies on a pair, leading a record"
    and (list? pair) (= 2 (count pair)) (record? (first pair))
  assert "|method by string or keyword"
    or (string? name) (keyword? name) (symbol? name)
  let
      proto $ nth pair 0
      f $ &get proto name
    assert "|expected function" (fn? f)
    f (nth pair 1) & params
```

Define 2 pieces of data, with 2 records holding their methods

```cirru
defrecord %Num :inc :add :dec :show

def Num $ %{} %Num
  :inc $ fn (x) $ [] Num (&+ x 1)
  :dec $ fn (x) $ [] Num (&- x 1)
  :add $ fn (x y)
    assert "|expected number" (number? y)
    [] Num (&+ x y)
  :show $ fn (x) $ str x
```

```cirru
defrecord %Point :inc :add :dec :show

def Point $ %{} %Point
  :inc $ fn (x)
    let[] (a b) x
      [] Point $ [] (&+ a 1) (&+ b 1)
  :dec $ fn (x)
    let[] (a b) x
      [] Point $ [] (&+ a 1) (&- b 1)
  :add $ fn (x y)
    assert "|expected point" $ and (list? y) (&= 2 (count y))
    let[] (a b) x
      let[] (c d) y
        [] Point $ [] (&+ a c) (&+ b d)
  :show $ fn (x)
    let[] (a b) x
      str "|(" a "|, " b "|)"
```

Then simulate ad-hoc polymorphism with dynamic calling:

```cirru
defn operation (a b)
  -> a
    invoke :inc
    invoke :inc
    invoke :inc
    invoke :inc
    invoke :add b
    invoke :show
    println

defn main! ()
  let
      a $ [] Num 0
      b $ [] Point $ [] 1 1

    operation a 10
    operation b ([] 10 10)
```