### PR TITLE
neater js code for case/cond

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.26"
+version = "0.3.27"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -28,7 +28,7 @@ export * from "./calcit-data";
 export * from "./record-procs";
 export * from "./custom-formatter";
 
-export const calcit_version = "0.3.25";
+export const calcit_version = "0.3.27";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.0.1",


### PR DESCRIPTION
with more detections, code from `case` and `cond` should try to use wrapped functions and `if`s for more readable js emission, rather then chaining ternary expressions.
