### PR TITLE
calcit-js: refactor Map internals; refine concat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.29"
+version = "0.3.30"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/calcit/snapshots/test-list.cirru
+++ b/calcit/snapshots/test-list.cirru
@@ -41,6 +41,12 @@
               assert "|concat lists" $ =
                 concat ([] 1 2) ([] 4 5) ([] 7 8)
                 [] 1 2 4 5 7 8
+              
+              assert=
+                [] 3 4 5 2 3
+                concat
+                  slice ([] 1 2 3 4 5 6) 2 5
+                  slice ([] 1 2 3 4 5 6) 1 3
               assert=
                 assoc (range 10) (, 4 55)
                 [] 0 1 2 3 55 5 6 7 8 9

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -20,6 +20,7 @@ import {
   getStringName,
   findInFields,
   CrDataTuple,
+  overwriteDataComparator,
 } from "./calcit-data";
 
 import { fieldsEqual } from "./record-procs";
@@ -28,7 +29,7 @@ export * from "./calcit-data";
 export * from "./record-procs";
 export * from "./custom-formatter";
 
-export const calcit_version = "0.3.29";
+export const calcit_version = "0.3.30";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 
@@ -124,12 +125,7 @@ export let _AND__MAP_ = (...xs: CrDataValue[]): CrDataMap => {
   if (xs.length % 2 !== 0) {
     throw new Error("&map expects even number of arguments");
   }
-  var dict: Array<[CrDataValue, CrDataValue]> = [];
-  let halfLength = xs.length >> 1;
-  for (let idx = 0; idx < halfLength; idx++) {
-    dict.push([xs[idx << 1], xs[(idx << 1) + 1]]);
-  }
-  return new CrDataMap(initTernaryTreeMap(dict));
+  return new CrDataMap(xs);
 };
 
 export let _AND_list_map = (...xs: CrDataValue[]): CrDataList => {
@@ -421,6 +417,7 @@ export let _AND__EQ_ = (x: CrDataValue, y: CrDataValue): boolean => {
 
 // overwrite internary comparator of ternary-tree
 overwriteComparator(_AND__EQ_);
+overwriteDataComparator(_AND__EQ_);
 
 export let _AND_str = (x: CrDataValue): string => {
   return `${x}`;

--- a/lib/custom-formatter.ts
+++ b/lib/custom-formatter.ts
@@ -104,8 +104,8 @@ export let load_console_formatter_BANG_ = () => {
           }
           if (obj instanceof CrDataMap) {
             let ret: any[] = ["div", { style: "color: hsl(280, 80%, 60%)" }];
-            obj.turnSingleMap();
-            for (let [k, v] of toPairs(obj.chain.value)) {
+            obj.turnMap();
+            for (let [k, v] of toPairs(obj.value)) {
               ret.push([
                 "div",
                 { style: "margin-left: 8px; display: flex;" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.1",


### PR DESCRIPTION
Add array mode operation in `concat` to reduce data conversion. Previously, combining `filter` and `concat` causes data conversion frequently.

Refactored implementation of `CrDataMap` trying to reduce cost in build tree. trade off is lookup algorithm efficiency become slower. It's supposed to gain lower memory occupation by using flat array here.