### PR TITLE
refactor implementation for methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.31"
+version = "0.3.32"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/calcit/snapshots/test-gynienic.cirru
+++ b/calcit/snapshots/test-gynienic.cirru
@@ -13,7 +13,7 @@
             let
                 c 11
               echo "\"internal c:" a b c
-              quote-replace $ do (echo "\"c is:" c)
+              quasiquote $ do (echo "\"c is:" c)
                 [] (~ a) (~ b) (, c) (~ c) (add-2 8)
     |test-gynienic.main $ {}
       :ns $ quote

--- a/calcit/snapshots/test-js.cirru
+++ b/calcit/snapshots/test-js.cirru
@@ -42,7 +42,7 @@
               set! (.-a a) 2
               assert= (.-a a) 2
 
-            assert= 2 $ nth (to-js-data $ [] 1 2 3) 1
+            assert= 2 $ aget (to-js-data $ [] 1 2 3) 1
 
             assert-detect identity $ instance? js/Number (new js/Number 1)
             assert-detect not $ instance? js/String (new js/Number 1)

--- a/calcit/snapshots/test-record.cirru
+++ b/calcit/snapshots/test-record.cirru
@@ -26,13 +26,13 @@
 
               assert= Person p0
 
-              assert= nil (&get Person :age)
-              assert= nil (&get Person 'age)
-              assert= nil (&get Person |age)
+              assert= nil (get Person :age)
+              assert= nil (get Person 'age)
+              assert= nil (get Person |age)
 
-              assert= 20 (&get p1 :age)
-              assert= 20 (&get p2 :age)
-              assert= 23 (&get p3 :age)
+              assert= 20 (get p1 :age)
+              assert= 20 (get p2 :age)
+              assert= 23 (get p3 :age)
 
               assert= :record $ type-of p1
               assert=
@@ -40,7 +40,7 @@
                 {} (:name |Chen) (:age 20) (:position :mainland)
 
               assert= 21
-                &get
+                get
                   make-record Person $ {}
                     :name |Chen
                     :age 21
@@ -57,8 +57,8 @@
 
               &let
                 p4 $ assoc p1 :age 30
-                assert= 20 $ &get p1 :age
-                assert= 30 $ &get p4 :age
+                assert= 20 $ get p1 :age
+                assert= 30 $ get p4 :age
 
               inside-js:
                 js/console.log $ to-js-data p1

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -233,8 +233,10 @@
           defrecord %Num :inc :show
         |Num $ quote
           def Num $ %{} %Num
-            :inc $ fn (x) $ :: Num (&+ x 1)
-            :show $ fn (x) $ str x
+            :inc $ fn (x)
+              update x 1 inc
+            :show $ fn (x)
+              str $ nth x 1
 
         |test-method $ quote
           fn ()

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -236,7 +236,7 @@
             :inc $ fn (x)
               update x 1 inc
             :show $ fn (x)
-              str $ nth x 1
+              str $ &tuple:nth x 1
 
         |test-method $ quote
           fn ()

--- a/calcit/snapshots/util.cirru
+++ b/calcit/snapshots/util.cirru
@@ -18,18 +18,18 @@
           defmacro inside-eval: (& body)
             if
               = :eval $ &get-calcit-running-mode
-              quote-replace
+              quasiquote
                 do (echo "|env: eval") ~@body
-              quote-replace
+              quasiquote
                 do (echo "|env: not eval. tests skipped")
 
         |inside-js: $ quote
           defmacro inside-js: (& body)
             if
               not= :eval $ &get-calcit-running-mode
-              quote-replace
+              quasiquote
                 do (echo "|env: js") ~@body
-              quote-replace
+              quasiquote
                 do (echo "|env: not js. tests skipped")
 
         |main! $ quote

--- a/lib/calcit-data.ts
+++ b/lib/calcit-data.ts
@@ -584,6 +584,11 @@ export class CrDataRecord {
   merge() {
     // TODO
   }
+  contains(k: CrDataValue) {
+    let field = getStringName(k);
+    let idx = findInFields(this.fields, field);
+    return idx >= 0;
+  }
   toString(): string {
     let ret = "(%{} " + this.name;
     for (let idx in this.fields) {

--- a/lib/calcit-data.ts
+++ b/lib/calcit-data.ts
@@ -134,6 +134,15 @@ export class CrDataTuple {
       throw new Error("Tuple only have 2 elements");
     }
   }
+  assoc(n: number, v: CrDataValue) {
+    if (n == 0) {
+      return new CrDataTuple(v, this.snd);
+    } else if (n == 1) {
+      return new CrDataTuple(this.fst, v);
+    } else {
+      throw new Error("Tuple only have 2 elements");
+    }
+  }
   toString(): string {
     return `(&tuple ${this.fst.toString()} ${this.snd.toString()})`;
   }

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -466,13 +466,18 @@ export let _AND_record_COL_contains_QUES_ = (xs: CrDataValue, x: CrDataValue): b
   throw new Error("record `contains?` expected a record");
 };
 
-export let includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
+export let _AND_str_COL_includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (typeof xs === "string") {
     if (typeof x !== "string") {
       throw new Error("Expected string");
     }
     return xs.includes(x as string);
   }
+
+  throw new Error("string includes? expected a string");
+};
+
+export let _AND_list_COL_includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (xs instanceof CrDataList) {
     let size = xs.len();
     for (let v of xs.items()) {
@@ -482,6 +487,11 @@ export let includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
     }
     return false;
   }
+
+  throw new Error("list includes? expected a list");
+};
+
+export let _AND_map_COL_includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (xs instanceof CrDataMap) {
     for (let [k, v] of xs.pairs()) {
       if (_AND__EQ_(v, x)) {
@@ -490,11 +500,16 @@ export let includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
     }
     return false;
   }
+
+  throw new Error("map includes? expected a map");
+};
+
+export let _AND_set_COL_includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (xs instanceof CrDataSet) {
     return xs.contains(x);
   }
 
-  throw new Error("includes? expected a structure");
+  throw new Error("set includes? expected a set");
 };
 
 export let nth = function (xs: CrDataValue, k: CrDataValue) {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -341,7 +341,7 @@ export let _AND__EQ_ = (x: CrDataValue, y: CrDataValue): boolean => {
         if (!y.contains(k)) {
           return false;
         }
-        if (!_AND__EQ_(v, _AND_get(y, k))) {
+        if (!_AND__EQ_(v, _AND_map_COL_get(y, k))) {
           return false;
         }
       }
@@ -553,26 +553,22 @@ export let _AND_record_COL_nth = function (xs: CrDataValue, k: CrDataValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _AND_get = function (xs: CrDataValue, k: CrDataValue) {
+export let _AND_map_COL_get = function (xs: CrDataValue, k: CrDataValue) {
   if (arguments.length !== 2) {
-    throw new Error("&get takes 2 arguments");
+    throw new Error("map &get takes 2 arguments");
   }
 
-  if (xs instanceof CrDataMap) {
-    return xs.get(k);
+  if (xs instanceof CrDataMap) return xs.get(k);
+
+  throw new Error("Does not support `&get` on this type");
+};
+
+export let _AND_record_COL_get = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) {
+    throw new Error("record &get takes 2 arguments");
   }
-  if (xs == null) {
-    throw new Error("`&get` does not work on `nil`, need to use `get`");
-  }
-  if (typeof xs === "string") {
-    return _AND_str_COL_nth(xs, k);
-  }
-  if (xs instanceof CrDataList) {
-    return _AND_list_COL_nth(xs, k);
-  }
-  if (xs instanceof CrDataRecord) {
-    return xs.get(k);
-  }
+
+  if (xs instanceof CrDataRecord) return xs.get(k);
 
   throw new Error("Does not support `&get` on this type");
 };
@@ -1659,6 +1655,9 @@ export let ref_QUES_ = (x: CrDataValue): boolean => {
 };
 export let record_QUES_ = (x: CrDataValue): boolean => {
   return x instanceof CrDataRecord;
+};
+export let tuple_QUES_ = (x: CrDataValue): boolean => {
+  return x instanceof CrDataTuple;
 };
 
 export let escape = (x: string) => JSON.stringify(x);

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -721,22 +721,24 @@ export function _AND_set_COL_empty_QUES_(xs: CrDataValue): boolean {
   throw new Error(`expected a list ${xs}`);
 }
 
-export let first = (xs: CrDataValue): CrDataValue => {
-  if (xs == null) {
-    return null;
-  }
+export let _AND_list_COL_first = (xs: CrDataValue): CrDataValue => {
   if (xs instanceof CrDataList) {
     if (xs.isEmpty()) {
       return null;
     }
     return xs.first();
   }
+  console.error(xs);
+  throw new Error("Expected a list");
+};
+export let _AND_str_COL_first = (xs: CrDataValue): CrDataValue => {
   if (typeof xs === "string") {
     return xs[0];
   }
-  if (xs instanceof CrDataSet) {
-    return xs.first();
-  }
+  console.error(xs);
+  throw new Error("Expected a string");
+};
+export let _AND_map_COL_first = (xs: CrDataValue): CrDataValue => {
   if (xs instanceof CrDataMap) {
     // TODO order may not be stable enough
     let ys = xs.pairs();
@@ -747,7 +749,15 @@ export let first = (xs: CrDataValue): CrDataValue => {
     }
   }
   console.error(xs);
-  throw new Error("Expects something sequential");
+  throw new Error("Expected a map");
+};
+export let _AND_set_COL_first = (xs: CrDataValue): CrDataValue => {
+  if (xs instanceof CrDataSet) {
+    return xs.first();
+  }
+
+  console.error(xs);
+  throw new Error("Expected a set");
 };
 
 export let timeout_call = (duration: number, f: CrDataFn): null => {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -29,7 +29,7 @@ export * from "./calcit-data";
 export * from "./record-procs";
 export * from "./custom-formatter";
 
-export const calcit_version = "0.3.31";
+export const calcit_version = "0.3.32";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -424,7 +424,7 @@ export let _AND_str = (x: CrDataValue): string => {
   return `${x}`;
 };
 
-export let contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
+export let _AND_str_COL_contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (typeof xs === "string") {
     if (typeof x != "number") {
       throw new Error("Expected number index for detecting");
@@ -435,6 +435,11 @@ export let contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
     }
     return false;
   }
+
+  throw new Error("string `contains?` expected a string");
+};
+
+export let _AND_list_COL_contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
   if (xs instanceof CrDataList) {
     if (typeof x != "number") {
       throw new Error("Expected number index for detecting");
@@ -445,18 +450,20 @@ export let contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
     }
     return false;
   }
-  if (xs instanceof CrDataMap) {
-    return xs.contains(x);
-  }
-  if (xs instanceof CrDataRecord) {
-    let pos = findInFields(xs.fields, getStringName(x));
-    return pos >= 0;
-  }
-  if (xs instanceof CrDataSet) {
-    throw new Error("Set expected `includes?` for detecting");
-  }
 
-  throw new Error("`contains?` expected a structure");
+  throw new Error("list `contains?` expected a list");
+};
+
+export let _AND_map_COL_contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
+  if (xs instanceof CrDataMap) return xs.contains(x);
+
+  throw new Error("map `contains?` expected a map");
+};
+
+export let _AND_record_COL_contains_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {
+  if (xs instanceof CrDataRecord) return xs.contains(x);
+
+  throw new Error("record `contains?` expected a record");
 };
 
 export let includes_QUES_ = (xs: CrDataValue, x: CrDataValue): boolean => {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -573,16 +573,20 @@ export let _AND_record_COL_get = function (xs: CrDataValue, k: CrDataValue) {
   throw new Error("Does not support `&get` on this type");
 };
 
-export let assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
-  if (arguments.length !== 3) {
-    throw new Error("assoc takes 3 arguments");
-  }
+export let _AND_list_COL_assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
+  if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
+
   if (xs instanceof CrDataList) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
     }
     return xs.assoc(k, v);
   }
+  throw new Error("list `assoc` expected a list");
+};
+export let _AND_tuple_COL_assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
+  if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
+
   if (xs instanceof CrDataTuple) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
@@ -590,15 +594,21 @@ export let assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
     return xs.assoc(k, v);
   }
 
-  if (xs instanceof CrDataMap) {
-    return xs.assoc(k, v);
-  }
+  throw new Error("tuple `assoc` expected a tuple");
+};
+export let _AND_map_COL_assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
+  if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
-  if (xs instanceof CrDataRecord) {
-    return xs.assoc(k, v);
-  }
+  if (xs instanceof CrDataMap) return xs.assoc(k, v);
 
-  throw new Error("Does not support `assoc` on this type");
+  throw new Error("map `assoc` expected a map");
+};
+export let _AND_record_COL_assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
+  if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
+
+  if (xs instanceof CrDataRecord) return xs.assoc(k, v);
+
+  throw new Error("record `assoc` expected a record");
 };
 
 export let assoc_before = function (xs: CrDataList, k: number, v: CrDataValue): CrDataList {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -771,19 +771,30 @@ export let timeout_call = (duration: number, f: CrDataFn): null => {
   return null;
 };
 
-export let rest = (xs: CrDataValue): CrDataValue => {
+export let _AND_list_COL_rest = (xs: CrDataValue): CrDataValue => {
   if (xs instanceof CrDataList) {
     if (xs.len() === 0) {
       return null;
     }
     return xs.rest();
   }
-  if (typeof xs === "string") {
-    return xs.substr(1);
-  }
-  if (xs instanceof CrDataSet) {
-    return xs.rest();
-  }
+  console.error(xs);
+  throw new Error("Expected a list");
+};
+
+export let _AND_str_COL_rest = (xs: CrDataValue): CrDataValue => {
+  if (typeof xs === "string") return xs.substr(1);
+
+  console.error(xs);
+  throw new Error("Expects a string");
+};
+export let _AND_set_COL_rest = (xs: CrDataValue): CrDataValue => {
+  if (xs instanceof CrDataSet) return xs.rest();
+
+  console.error(xs);
+  throw new Error("Expect a set");
+};
+export let _AND_map_COL_rest = (xs: CrDataValue): CrDataValue => {
   if (xs instanceof CrDataMap) {
     if (xs.len() > 0) {
       let k0 = xs.pairs()[0][0];
@@ -793,8 +804,7 @@ export let rest = (xs: CrDataValue): CrDataValue => {
     }
   }
   console.error(xs);
-
-  throw new Error("Expects something sequential");
+  throw new Error("Expected map");
 };
 
 export let recur = (...xs: CrDataValue[]): CrDataRecur => {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -670,26 +670,23 @@ export let range = (n: number, m: number, m2: number): CrDataList => {
   return result;
 };
 
-export let empty_QUES_ = (xs: CrDataValue): boolean => {
-  if (typeof xs == "string") {
-    return xs.length == 0;
-  }
-  if (xs instanceof CrDataList) {
-    return xs.isEmpty();
-  }
-  if (xs instanceof CrDataMap) {
-    return xs.isEmpty();
-  }
-  if (xs instanceof CrDataSet) {
-    return xs.len() === 0;
-  }
-  if (xs == null) {
-    return true;
-  }
+export function _AND_list_COL_empty_QUES_(xs: CrDataValue): boolean {
+  if (xs instanceof CrDataList) return xs.isEmpty();
+  throw new Error(`expected a list ${xs}`);
+}
+export function _AND_str_COL_empty_QUES_(xs: CrDataValue): boolean {
+  if (typeof xs == "string") return xs.length == 0;
+  throw new Error(`expected a string ${xs}`);
+}
+export function _AND_map_COL_empty_QUES_(xs: CrDataValue): boolean {
+  if (xs instanceof CrDataMap) return xs.isEmpty();
 
-  console.error(xs);
-  throw new Error("Does not support `empty?` on this type");
-};
+  throw new Error(`expected a list ${xs}`);
+}
+export function _AND_set_COL_empty_QUES_(xs: CrDataValue): boolean {
+  if (xs instanceof CrDataSet) return xs.len() === 0;
+  throw new Error(`expected a list ${xs}`);
+}
 
 export let first = (xs: CrDataValue): CrDataValue => {
   if (xs == null) {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -639,22 +639,23 @@ export let assoc_after = function (xs: CrDataList, k: number, v: CrDataValue): C
   throw new Error("Does not support `assoc-after` on this type");
 };
 
-export let dissoc = function (xs: CrDataValue, k: CrDataValue) {
-  if (arguments.length !== 2) {
-    throw new Error("dissoc takes 2 arguments");
-  }
+export let _AND_list_COL_dissoc = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("dissoc takes 2 arguments");
 
   if (xs instanceof CrDataList) {
-    if (typeof k !== "number") {
-      throw new Error("Expected number index for lists");
-    }
-    return xs.dissoc(k);
-  }
-  if (xs instanceof CrDataMap) {
+    if (typeof k !== "number") throw new Error("Expected number index for lists");
+
     return xs.dissoc(k);
   }
 
-  throw new Error("Does not support `dissoc` on this type");
+  throw new Error("`dissoc` expected a list");
+};
+export let _AND_map_COL_dissoc = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("dissoc takes 2 arguments");
+
+  if (xs instanceof CrDataMap) return xs.dissoc(k);
+
+  throw new Error("`dissoc` expected a map");
 };
 
 export let reset_BANG_ = (a: CrDataRef, v: CrDataValue): null => {

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -554,6 +554,12 @@ export let assoc = function (xs: CrDataValue, k: CrDataValue, v: CrDataValue) {
     }
     return xs.assoc(k, v);
   }
+  if (xs instanceof CrDataTuple) {
+    if (typeof k !== "number") {
+      throw new Error("Expected number index for lists");
+    }
+    return xs.assoc(k, v);
+  }
 
   if (xs instanceof CrDataMap) {
     return xs.assoc(k, v);
@@ -1767,11 +1773,10 @@ export let register_calcit_builtin_classes = (options: typeof calcit_builtin_cla
 export function invoke_method(p: string) {
   return (obj: CrDataValue, ...args: CrDataValue[]) => {
     let klass: CrDataRecord;
-    let rawValue = obj;
+    let value = obj;
     if (obj instanceof CrDataTuple) {
       if (obj.fst instanceof CrDataRecord) {
         klass = obj.fst;
-        rawValue = obj.snd;
       } else {
         throw new Error("Method invoking expected a record as class");
       }
@@ -1795,7 +1800,7 @@ export function invoke_method(p: string) {
     }
     let method = klass.get(p);
     if (typeof method === "function") {
-      return method(rawValue, ...args);
+      return method(value, ...args);
     } else {
       throw new Error("Method for invoking is not a function");
     }

--- a/lib/calcit.procs.ts
+++ b/lib/calcit.procs.ts
@@ -512,31 +512,42 @@ export let _AND_set_COL_includes_QUES_ = (xs: CrDataValue, x: CrDataValue): bool
   throw new Error("set includes? expected a set");
 };
 
-export let nth = function (xs: CrDataValue, k: CrDataValue) {
-  if (arguments.length !== 2) {
-    throw new Error("nth takes 2 arguments");
-  }
-  if (typeof k !== "number") {
-    throw new Error("Expected number index for a list");
-  }
+export let _AND_str_COL_nth = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
+  if (typeof k !== "number") throw new Error("Expected number index for a list");
 
-  if (typeof xs === "string") {
-    return xs[k];
-  }
-  if (xs instanceof CrDataList) {
-    return xs.get(k);
-  }
-  if (xs instanceof CrDataTuple) {
-    return xs.get(k);
-  }
+  if (typeof xs === "string") return xs[k];
+
+  throw new Error("Does not support `nth` on this type");
+};
+
+export let _AND_list_COL_nth = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
+  if (typeof k !== "number") throw new Error("Expected number index for a list");
+
+  if (xs instanceof CrDataList) return xs.get(k);
+
+  throw new Error("Does not support `nth` on this type");
+};
+
+export let _AND_tuple_COL_nth = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
+  if (typeof k !== "number") throw new Error("Expected number index for a list");
+
+  if (xs instanceof CrDataTuple) return xs.get(k);
+
+  throw new Error("Does not support `nth` on this type");
+};
+
+export let _AND_record_COL_nth = function (xs: CrDataValue, k: CrDataValue) {
+  if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
+  if (typeof k !== "number") throw new Error("Expected number index for a list");
+
   if (xs instanceof CrDataRecord) {
     if (k < 0 || k >= xs.fields.length) {
       throw new Error("Out of bound");
     }
     return new CrDataList([kwd(xs.fields[k]), xs.values[k]]);
-  }
-  if (Array.isArray(xs)) {
-    return xs[k];
   }
 
   throw new Error("Does not support `nth` on this type");
@@ -554,10 +565,10 @@ export let _AND_get = function (xs: CrDataValue, k: CrDataValue) {
     throw new Error("`&get` does not work on `nil`, need to use `get`");
   }
   if (typeof xs === "string") {
-    return nth(xs, k);
+    return _AND_str_COL_nth(xs, k);
   }
   if (xs instanceof CrDataList) {
-    return nth(xs, k);
+    return _AND_list_COL_nth(xs, k);
   }
   if (xs instanceof CrDataRecord) {
     return xs.get(k);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -98,6 +98,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "escape"
       | "&str:count"
       | "&str:empty?"
+      | "&str:contains?"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
@@ -115,11 +116,11 @@ pub fn is_proc_name(s: &str) -> bool {
       | "first"
       | "assoc-before"
       | "assoc-after"
+      | "&list:contains?"
       // maps
       | "&{}"
       | "assoc"
       | "&get"
-      | "contains?"
       | "dissoc"
       | "&merge"
       | "includes?"
@@ -128,6 +129,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&map:to-list"
       | "&map:count"
       | "&map:empty?"
+      | "&map:contains?"
       // sets
       | "#{}"
       | "&include"
@@ -153,6 +155,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "turn-map"
       | "relevant-record?" // regexs
       | "&record:count"
+      | "&record:contains?"
   )
 }
 
@@ -235,6 +238,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "escape" => strings::escape(args),
     "&str:count" => strings::count(args),
     "&str:empty?" => strings::empty_ques(args),
+    "&str:contains?" => strings::contains_ques(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -243,8 +247,6 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     // lists
     "[]" => lists::new_list(args),
     "'" => lists::new_list(args), // alias
-    "&list:count" => lists::count(args),
-    "&list:empty?" => lists::empty_ques(args),
     "nth" => lists::nth(args),
     "slice" => lists::slice(args),
     "append" => lists::append(args),
@@ -257,11 +259,13 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "first" => lists::first(args),
     "assoc-before" => lists::assoc_before(args),
     "assoc-after" => lists::assoc_after(args),
+    "&list:count" => lists::count(args),
+    "&list:empty?" => lists::empty_ques(args),
+    "&list:contains?" => lists::contains_ques(args),
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
     "&get" => maps::map_get(args),
-    "contains?" => maps::contains_ques(args),
     "dissoc" => maps::dissoc(args),
     "&merge" => maps::call_merge(args),
     "includes?" => maps::includes_ques(args),
@@ -270,6 +274,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:to-list" => maps::to_list(args),
     "&map:count" => maps::count(args),
     "&map:empty?" => maps::empty_ques(args),
+    "&map:contains?" => maps::contains_ques(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -295,6 +300,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "turn-map" => records::turn_map(args),
     "relevant-record?" => records::relevant_record_ques(args),
     "&record:count" => records::count(args),
+    "&record:contains?" => records::contains_ques(args),
     a => Err(format!("No such proc: {}", a)),
   }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -126,7 +126,7 @@ pub fn is_proc_name(s: &str) -> bool {
       // maps
       | "&{}"
       | "assoc"
-      | "&get"
+      | "&map:get"
       | "dissoc"
       | "&merge"
       | "to-pairs"
@@ -168,6 +168,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&record:count"
       | "&record:contains?"
       | "&record:nth"
+      | "&record:get"
   )
 }
 
@@ -283,7 +284,6 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
-    "&get" => maps::map_get(args),
     "dissoc" => maps::dissoc(args),
     "&merge" => maps::call_merge(args),
     "to-pairs" => maps::to_pairs(args),
@@ -295,6 +295,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:includes?" => maps::includes_ques(args),
     "&map:first" => maps::first(args),
     "&map:rest" => maps::rest(args),
+    "&map:get" => maps::get(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -325,6 +326,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&record:count" => records::count(args),
     "&record:contains?" => records::contains_ques(args),
     "&record:nth" => records::nth(args),
+    "&record:get" => records::get(args),
     a => Err(format!("No such proc: {}", a)),
   }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -102,6 +102,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&str:contains?"
       | "&str:includes?"
       | "&str:nth"
+      | "&str:first"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
@@ -115,12 +116,12 @@ pub fn is_proc_name(s: &str) -> bool {
       | "concat"
       | "range"
       | "reverse"
-      | "first"
       | "assoc-before"
       | "assoc-after"
       | "&list:contains?"
       | "&list:includes?"
       | "&list:nth"
+      | "&list:first"
       // maps
       | "&{}"
       | "assoc"
@@ -134,6 +135,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&map:empty?"
       | "&map:contains?"
       | "&map:includes?"
+      | "&map:first"
       // sets
       | "#{}"
       | "&include"
@@ -145,6 +147,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&set:count"
       | "&set:empty?"
       | "&set:includes?"
+      | "&set:first"
       // json
       | "parse-json"
       | "stringify-json"
@@ -248,6 +251,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&str:contains?" => strings::contains_ques(args),
     "&str:includes?" => strings::includes_ques(args),
     "&str:nth" => strings::nth(args),
+    "&str:first" => strings::first(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -264,7 +268,6 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "concat" => lists::concat(args),
     "range" => lists::range(args),
     "reverse" => lists::reverse(args),
-    "first" => lists::first(args),
     "assoc-before" => lists::assoc_before(args),
     "assoc-after" => lists::assoc_after(args),
     "&list:count" => lists::count(args),
@@ -272,6 +275,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:contains?" => lists::contains_ques(args),
     "&list:includes?" => lists::includes_ques(args),
     "&list:nth" => lists::nth(args),
+    "&list:first" => lists::first(args),
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
@@ -285,6 +289,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:empty?" => maps::empty_ques(args),
     "&map:contains?" => maps::contains_ques(args),
     "&map:includes?" => maps::includes_ques(args),
+    "&map:first" => maps::first(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -296,6 +301,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&set:count" => sets::count(args),
     "&set:empty?" => sets::empty_ques(args),
     "&set:includes?" => sets::includes_ques(args),
+    "&set:first" => sets::first(args),
     // json
     "parse-json" => json::parse_json(args),
     "stringify-json" => json::stringify_json(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -99,6 +99,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&str:count"
       | "&str:empty?"
       | "&str:contains?"
+      | "&str:includes?"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
@@ -117,19 +118,20 @@ pub fn is_proc_name(s: &str) -> bool {
       | "assoc-before"
       | "assoc-after"
       | "&list:contains?"
+      | "&list:includes?"
       // maps
       | "&{}"
       | "assoc"
       | "&get"
       | "dissoc"
       | "&merge"
-      | "includes?"
       | "to-pairs"
       | "&merge-non-nil"
       | "&map:to-list"
       | "&map:count"
       | "&map:empty?"
       | "&map:contains?"
+      | "&map:includes?"
       // sets
       | "#{}"
       | "&include"
@@ -140,6 +142,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "set->list"
       | "&set:count"
       | "&set:empty?"
+      | "&set:includes?"
       // json
       | "parse-json"
       | "stringify-json"
@@ -239,6 +242,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&str:count" => strings::count(args),
     "&str:empty?" => strings::empty_ques(args),
     "&str:contains?" => strings::contains_ques(args),
+    "&str:includes?" => strings::includes_ques(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -262,19 +266,20 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:count" => lists::count(args),
     "&list:empty?" => lists::empty_ques(args),
     "&list:contains?" => lists::contains_ques(args),
+    "&list:includes?" => lists::includes_ques(args),
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
     "&get" => maps::map_get(args),
     "dissoc" => maps::dissoc(args),
     "&merge" => maps::call_merge(args),
-    "includes?" => maps::includes_ques(args),
     "to-pairs" => maps::to_pairs(args),
     "&merge-non-nil" => maps::call_merge_non_nil(args),
     "&map:to-list" => maps::to_list(args),
     "&map:count" => maps::count(args),
     "&map:empty?" => maps::empty_ques(args),
     "&map:contains?" => maps::contains_ques(args),
+    "&map:includes?" => maps::includes_ques(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -285,6 +290,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "set->list" => sets::set_to_list(args),
     "&set:count" => sets::count(args),
     "&set:empty?" => sets::empty_ques(args),
+    "&set:includes?" => sets::includes_ques(args),
     // json
     "parse-json" => json::parse_json(args),
     "stringify-json" => json::stringify_json(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -103,6 +103,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&str:includes?"
       | "&str:nth"
       | "&str:first"
+      | "&str:rest"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
@@ -111,7 +112,6 @@ pub fn is_proc_name(s: &str) -> bool {
       | "slice"
       | "append"
       | "prepend"
-      | "rest"
       | "butlast"
       | "concat"
       | "range"
@@ -122,6 +122,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&list:includes?"
       | "&list:nth"
       | "&list:first"
+      | "&list:rest"
       // maps
       | "&{}"
       | "assoc"
@@ -136,6 +137,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&map:contains?"
       | "&map:includes?"
       | "&map:first"
+      | "&map:rest"
       // sets
       | "#{}"
       | "&include"
@@ -148,6 +150,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&set:empty?"
       | "&set:includes?"
       | "&set:first"
+      | "&set:rest"
       // json
       | "parse-json"
       | "stringify-json"
@@ -252,6 +255,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&str:includes?" => strings::includes_ques(args),
     "&str:nth" => strings::nth(args),
     "&str:first" => strings::first(args),
+    "&str:rest" => strings::rest(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -263,7 +267,6 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "slice" => lists::slice(args),
     "append" => lists::append(args),
     "prepend" => lists::prepend(args),
-    "rest" => lists::rest(args),
     "butlast" => lists::butlast(args),
     "concat" => lists::concat(args),
     "range" => lists::range(args),
@@ -276,6 +279,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:includes?" => lists::includes_ques(args),
     "&list:nth" => lists::nth(args),
     "&list:first" => lists::first(args),
+    "&list:rest" => lists::rest(args),
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
@@ -290,6 +294,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:contains?" => maps::contains_ques(args),
     "&map:includes?" => maps::includes_ques(args),
     "&map:first" => maps::first(args),
+    "&map:rest" => maps::rest(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -302,6 +307,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&set:empty?" => sets::empty_ques(args),
     "&set:includes?" => sets::includes_ques(args),
     "&set:first" => sets::first(args),
+    "&set:rest" => sets::rest(args),
     // json
     "parse-json" => json::parse_json(args),
     "stringify-json" => json::stringify_json(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -36,6 +36,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "::" // unstable
       | "&compare"
       | "&tuple:nth"
+      | "&tuple:assoc"
       // effects
       | "echo"
       | "println" // alias for echo
@@ -123,9 +124,9 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&list:nth"
       | "&list:first"
       | "&list:rest"
+      | "&list:assoc"
       // maps
       | "&{}"
-      | "assoc"
       | "&map:get"
       | "dissoc"
       | "&merge"
@@ -138,6 +139,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&map:includes?"
       | "&map:first"
       | "&map:rest"
+      | "&map:assoc"
       // sets
       | "#{}"
       | "&include"
@@ -151,6 +153,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&set:includes?"
       | "&set:first"
       | "&set:rest"
+      | "&set:assoc"
       // json
       | "parse-json"
       | "stringify-json"
@@ -169,6 +172,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&record:contains?"
       | "&record:nth"
       | "&record:get"
+      | "&record:assoc"
   )
 }
 
@@ -189,9 +193,10 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "write-cirru-edn" => meta::write_cirru_edn(args),
     "turn-symbol" => meta::turn_symbol(args),
     "turn-keyword" => meta::turn_keyword(args),
-    "::" => meta::new_tuple(args),            // unstable solution for the name
-    "&compare" => meta::native_compare(args), // unstable solution for the name
-    "&tuple:nth" => meta::tuple_nth(args),    // unstable solution for the name
+    "::" => meta::new_tuple(args), // unstable solution for the name
+    "&compare" => meta::native_compare(args),
+    "&tuple:nth" => meta::tuple_nth(args),
+    "&tuple:assoc" => meta::assoc(args),
     // effects
     "echo" => effects::echo(args),
     "println" => effects::echo(args), // alias
@@ -281,9 +286,9 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:nth" => lists::nth(args),
     "&list:first" => lists::first(args),
     "&list:rest" => lists::rest(args),
+    "&list:assoc" => lists::assoc(args),
     // maps
     "&{}" => maps::call_new_map(args),
-    "assoc" => maps::assoc(args),
     "dissoc" => maps::dissoc(args),
     "&merge" => maps::call_merge(args),
     "to-pairs" => maps::to_pairs(args),
@@ -296,6 +301,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:first" => maps::first(args),
     "&map:rest" => maps::rest(args),
     "&map:get" => maps::get(args),
+    "&map:assoc" => maps::assoc(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -327,6 +333,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&record:contains?" => records::contains_ques(args),
     "&record:nth" => records::nth(args),
     "&record:get" => records::get(args),
+    "&record:assoc" => records::assoc(args),
     a => Err(format!("No such proc: {}", a)),
   }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -97,11 +97,12 @@ pub fn is_proc_name(s: &str) -> bool {
       | "blank?"
       | "escape"
       | "&str:count"
+      | "&str:empty?"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
-      | "empty?"
       | "&list:count"
+      | "&list:empty?"
       | "nth"
       | "slice"
       | "append"
@@ -126,6 +127,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&merge-non-nil"
       | "&map:to-list"
       | "&map:count"
+      | "&map:empty?"
       // sets
       | "#{}"
       | "&include"
@@ -135,6 +137,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&intersection"
       | "set->list"
       | "&set:count"
+      | "&set:empty?"
       // json
       | "parse-json"
       | "stringify-json"
@@ -231,6 +234,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "blank?" => strings::blank_ques(args),
     "escape" => strings::escape(args),
     "&str:count" => strings::count(args),
+    "&str:empty?" => strings::empty_ques(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -239,8 +243,8 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     // lists
     "[]" => lists::new_list(args),
     "'" => lists::new_list(args), // alias
-    "empty?" => lists::empty_ques(args),
     "&list:count" => lists::count(args),
+    "&list:empty?" => lists::empty_ques(args),
     "nth" => lists::nth(args),
     "slice" => lists::slice(args),
     "append" => lists::append(args),
@@ -265,6 +269,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&merge-non-nil" => maps::call_merge_non_nil(args),
     "&map:to-list" => maps::to_list(args),
     "&map:count" => maps::count(args),
+    "&map:empty?" => maps::empty_ques(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),
@@ -274,6 +279,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&intersection" => sets::call_intersection(args),
     "set->list" => sets::set_to_list(args),
     "&set:count" => sets::count(args),
+    "&set:empty?" => sets::empty_ques(args),
     // json
     "parse-json" => json::parse_json(args),
     "stringify-json" => json::stringify_json(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -125,10 +125,11 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&list:first"
       | "&list:rest"
       | "&list:assoc"
+      | "&list:dissoc"
       // maps
       | "&{}"
       | "&map:get"
-      | "dissoc"
+      | "&map:dissoc"
       | "&merge"
       | "to-pairs"
       | "&merge-non-nil"
@@ -287,9 +288,9 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:first" => lists::first(args),
     "&list:rest" => lists::rest(args),
     "&list:assoc" => lists::assoc(args),
+    "&list:dissoc" => lists::dissoc(args),
     // maps
     "&{}" => maps::call_new_map(args),
-    "dissoc" => maps::dissoc(args),
     "&merge" => maps::call_merge(args),
     "to-pairs" => maps::to_pairs(args),
     "&merge-non-nil" => maps::call_merge_non_nil(args),
@@ -302,6 +303,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&map:rest" => maps::rest(args),
     "&map:get" => maps::get(args),
     "&map:assoc" => maps::assoc(args),
+    "&map:dissoc" => maps::dissoc(args),
     // sets
     "#{}" => sets::new_set(args),
     "&include" => sets::call_include(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -35,6 +35,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "turn-keyword"
       | "::" // unstable
       | "&compare"
+      | "&tuple:nth"
       // effects
       | "echo"
       | "println" // alias for echo
@@ -100,12 +101,12 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&str:empty?"
       | "&str:contains?"
       | "&str:includes?"
+      | "&str:nth"
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
       | "&list:count"
       | "&list:empty?"
-      | "nth"
       | "slice"
       | "append"
       | "prepend"
@@ -119,6 +120,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "assoc-after"
       | "&list:contains?"
       | "&list:includes?"
+      | "&list:nth"
       // maps
       | "&{}"
       | "assoc"
@@ -159,6 +161,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "relevant-record?" // regexs
       | "&record:count"
       | "&record:contains?"
+      | "&record:nth"
   )
 }
 
@@ -181,6 +184,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "turn-keyword" => meta::turn_keyword(args),
     "::" => meta::new_tuple(args),            // unstable solution for the name
     "&compare" => meta::native_compare(args), // unstable solution for the name
+    "&tuple:nth" => meta::tuple_nth(args),    // unstable solution for the name
     // effects
     "echo" => effects::echo(args),
     "println" => effects::echo(args), // alias
@@ -243,6 +247,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&str:empty?" => strings::empty_ques(args),
     "&str:contains?" => strings::contains_ques(args),
     "&str:includes?" => strings::includes_ques(args),
+    "&str:nth" => strings::nth(args),
     // regex
     "re-matches" => regexes::re_matches(args),
     "re-find" => regexes::re_find(args),
@@ -251,7 +256,6 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     // lists
     "[]" => lists::new_list(args),
     "'" => lists::new_list(args), // alias
-    "nth" => lists::nth(args),
     "slice" => lists::slice(args),
     "append" => lists::append(args),
     "prepend" => lists::prepend(args),
@@ -267,6 +271,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&list:empty?" => lists::empty_ques(args),
     "&list:contains?" => lists::contains_ques(args),
     "&list:includes?" => lists::includes_ques(args),
+    "&list:nth" => lists::nth(args),
     // maps
     "&{}" => maps::call_new_map(args),
     "assoc" => maps::assoc(args),
@@ -307,6 +312,7 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "relevant-record?" => records::relevant_record_ques(args),
     "&record:count" => records::count(args),
     "&record:contains?" => records::contains_ques(args),
+    "&record:nth" => records::nth(args),
     a => Err(format!("No such proc: {}", a)),
   }
 }

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -11,19 +11,6 @@ pub fn new_list(xs: &CalcitItems) -> Result<Calcit, String> {
   Ok(Calcit::List(xs.clone()))
 }
 
-pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
-  match xs.get(0) {
-    Some(Calcit::Nil) => Ok(Calcit::Bool(true)),
-    Some(Calcit::Tuple(..)) => Ok(Calcit::Bool(false)),
-    Some(Calcit::List(ys)) => Ok(Calcit::Bool(ys.is_empty())),
-    Some(Calcit::Map(ys)) => Ok(Calcit::Bool(ys.is_empty())),
-    Some(Calcit::Set(ys)) => Ok(Calcit::Bool(ys.is_empty())),
-    Some(Calcit::Str(s)) => Ok(Calcit::Bool(s.is_empty())),
-    Some(a) => Err(format!("empty? expected some seq, got: {}", a)),
-    None => Err(String::from("empty? expected 1 argument")),
-  }
-}
-
 pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     Some(Calcit::List(ys)) => Ok(Calcit::Number(ys.len() as f64)),
@@ -547,5 +534,13 @@ pub fn assoc_after(xs: &CalcitItems) -> Result<Calcit, String> {
     },
     (Some(a), Some(b), Some(c)) => Err(format!("assoc-after expected list and index, got: {} {} {}", a, b, c)),
     (a, b, c) => Err(format!("invalid arguments to assoc-after: {:?} {:?} {:?}", a, b, c)),
+  }
+}
+
+pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::List(ys)) => Ok(Calcit::Bool(ys.is_empty())),
+    Some(a) => Err(format!("list empty? expected a list, got: {}", a)),
+    None => Err(String::from("list empty? expected 1 argument")),
   }
 }

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -491,3 +491,22 @@ pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("list `includes?` expected 2 arguments, got: {:?}", xs)),
   }
 }
+
+pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1), xs.get(2)) {
+    (Some(Calcit::List(xs)), Some(Calcit::Number(n)), Some(a)) => match f64_to_usize(*n) {
+      Ok(idx) => {
+        if idx < xs.len() {
+          let mut ys = xs.clone();
+          ys[idx] = a.clone();
+          Ok(Calcit::List(ys))
+        } else {
+          Ok(Calcit::Nil)
+        }
+      }
+      Err(e) => Err(e),
+    },
+    (Some(a), ..) => Err(format!("list:assoc expected list, got: {}", a)),
+    (None, ..) => Err(format!("list:assoc expected 3 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -510,3 +510,18 @@ pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("list:assoc expected 3 arguments, got: {:?}", xs)),
   }
 }
+
+pub fn dissoc(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::List(xs)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(idx) => {
+        let ys = &mut xs.clone();
+        ys.remove(idx);
+        Ok(Calcit::List(ys.clone()))
+      }
+      Err(e) => Err(format!("dissoc expected number, {}", e)),
+    },
+    (Some(a), ..) => Err(format!("list dissoc expected a list, got: {}", a)),
+    (_, _) => Err(format!("list dissoc expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -555,3 +555,11 @@ pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("list contains? expected 2 arguments, got: {:?}", xs)),
   }
 }
+
+pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::List(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains(a))),
+    (Some(a), ..) => Err(format!("list `includes?` expected list, list, got: {}", a)),
+    (None, ..) => Err(format!("list `includes?` expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -1,6 +1,6 @@
 use core::cmp::Ordering;
 
-use crate::primes::{Calcit, CalcitItems, CalcitScope};
+use crate::primes::{Calcit, CalcitItems, CalcitScope, CrListWrap};
 use crate::util::number::f64_to_usize;
 
 use crate::builtins;
@@ -21,13 +21,6 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
 
 pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::Nil), Some(Calcit::Number(_))) => Ok(Calcit::Nil),
-    (Some(Calcit::Tuple(a, b)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(0) => Ok((**a).clone()),
-      Ok(1) => Ok((**b).to_owned()),
-      Ok(m) => Err(format!("Tuple only got 2 elements, trying to index with {}", m)),
-      Err(e) => Err(format!("nth expect usize, {}", e)),
-    },
     (Some(Calcit::List(ys)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
       Ok(idx) => match ys.get(idx) {
         Some(v) => Ok(v.clone()),
@@ -35,29 +28,9 @@ pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
       },
       Err(e) => Err(format!("nth expect usize, {}", e)),
     },
-    (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => match s.chars().nth(idx) {
-        Some(v) => Ok(Calcit::Str(v.to_string())),
-        None => Ok(Calcit::Nil),
-      },
-      Err(e) => Err(format!("nth expect usize, {}", e)),
-    },
-    (Some(Calcit::Record(_name, fields, values)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => {
-        if idx < fields.len() {
-          Ok(Calcit::List(im::vector![
-            Calcit::Keyword(fields[idx].clone()),
-            values[idx].clone()
-          ]))
-        } else {
-          Ok(Calcit::Nil)
-        }
-      }
-      Err(e) => Err(format!("nth expect usize, {}", e)),
-    },
-    (Some(_), None) => Err(format!("nth expected a ordered seq and index, got: {:?}", xs)),
-    (None, Some(_)) => Err(format!("nth expected a ordered seq and index, got: {:?}", xs)),
-    (_, _) => Err(format!("nth expected 2 argument, got: {:?}", xs)),
+    (Some(_), None) => Err(format!("string nth expected a list and index, got: {:?}", xs)),
+    (None, Some(_)) => Err(format!("string nth expected a list and index, got: {:?}", xs)),
+    (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }
 

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -544,3 +544,14 @@ pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("list empty? expected 1 argument")),
   }
 }
+
+pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::List(xs)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(idx) => Ok(Calcit::Bool(idx < xs.len())),
+      Err(e) => Err(e),
+    },
+    (Some(a), ..) => Err(format!("list contains? expected list, got: {}", a)),
+    (None, ..) => Err(format!("list contains? expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -449,10 +449,8 @@ pub fn sort(
   }
 }
 
-/// use builtin function since sets need to be handled specifically
 pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
-    Some(Calcit::Nil) => Ok(Calcit::Nil),
     Some(Calcit::List(ys)) => {
       if ys.is_empty() {
         Ok(Calcit::Nil)
@@ -460,22 +458,8 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
         Ok(ys[0].clone())
       }
     }
-    Some(Calcit::Set(ys)) => match ys.iter().next() {
-      // TODO first element of a set.. need to be more sure...
-      Some(v) => Ok(v.clone()),
-      None => Ok(Calcit::Nil),
-    },
-    Some(Calcit::Map(ys)) => match ys.iter().next() {
-      // TODO order may not be stable enough
-      Some((k, v)) => Ok(Calcit::List(im::vector![k.to_owned(), v.to_owned()])),
-      None => Ok(Calcit::Nil),
-    },
-    Some(Calcit::Str(s)) => match s.chars().next() {
-      Some(c) => Ok(Calcit::Str(c.to_string())),
-      None => Ok(Calcit::Nil),
-    },
-    Some(a) => Err(format!("first expected a list, got: {}", a)),
-    None => Err(String::from("first expected 1 argument")),
+    Some(a) => Err(format!("list:first expected a list, got: {}", a)),
+    None => Err(String::from("list:first expected 1 argument")),
   }
 }
 

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -80,7 +80,6 @@ pub fn prepend(xs: &CalcitItems) -> Result<Calcit, String> {
 
 pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
-    Some(Calcit::Nil) => Ok(Calcit::Nil),
     Some(Calcit::List(ys)) => {
       if ys.is_empty() {
         Ok(Calcit::Nil)
@@ -90,36 +89,8 @@ pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
         Ok(Calcit::List(zs))
       }
     }
-    Some(Calcit::Set(ys)) => match ys.iter().next() {
-      Some(y0) => {
-        let mut zs = ys.clone();
-        zs.remove(y0);
-        Ok(Calcit::Set(zs))
-      }
-      None => Ok(Calcit::Nil),
-    },
-    Some(Calcit::Map(ys)) => match ys.keys().next() {
-      Some(k0) => {
-        let mut zs = ys.clone();
-        zs.remove(k0);
-        Ok(Calcit::Map(zs))
-      }
-      None => Ok(Calcit::Nil),
-    },
-    Some(Calcit::Str(s)) => {
-      let mut buffer = String::from("");
-      let mut is_first = true;
-      for c in s.chars() {
-        if is_first {
-          is_first = false;
-          continue;
-        }
-        buffer.push(c)
-      }
-      Ok(Calcit::Str(buffer.to_owned()))
-    }
-    Some(a) => Err(format!("rest expected a list, got: {}", a)),
-    None => Err(String::from("rest expected 1 argument")),
+    Some(a) => Err(format!("list:rest expected a list, got: {}", a)),
+    None => Err(String::from("list:rest expected 1 argument")),
   }
 }
 

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -253,3 +253,18 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("map:first expected 1 argument")),
   }
 }
+
+pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Map(ys)) => match ys.keys().next() {
+      Some(k0) => {
+        let mut zs = ys.clone();
+        zs.remove(k0);
+        Ok(Calcit::Map(zs))
+      }
+      None => Ok(Calcit::Nil),
+    },
+    Some(a) => Err(format!("map:rest expected a map, got: {}", a)),
+    None => Err(String::from("map:rest expected 1 argument")),
+  }
+}

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -83,22 +83,8 @@ pub fn dissoc(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-pub fn map_get(xs: &CalcitItems) -> Result<Calcit, String> {
+pub fn get(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::List(xs)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => match xs.get(idx) {
-        Some(v) => Ok(v.clone()),
-        None => Ok(Calcit::Nil),
-      },
-      Err(e) => Err(e),
-    },
-    (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => match s.chars().nth(idx) {
-        Some(v) => Ok(Calcit::Str(v.to_string())),
-        None => Ok(Calcit::Nil),
-      },
-      Err(e) => Err(e),
-    },
     (Some(Calcit::Map(xs)), Some(a)) => {
       let ys = &mut xs.clone();
       match ys.get(a) {
@@ -106,15 +92,8 @@ pub fn map_get(xs: &CalcitItems) -> Result<Calcit, String> {
         None => Ok(Calcit::Nil),
       }
     }
-    (Some(Calcit::Record(_name, fields, values)), Some(a)) => match a {
-      Calcit::Str(k) | Calcit::Keyword(k) | Calcit::Symbol(k, ..) => match find_in_fields(fields, k) {
-        Some(idx) => Ok(values[idx].clone()),
-        None => Ok(Calcit::Nil),
-      },
-      a => Err(format!("record field expected to be string/keyword, got {}", a)),
-    },
-    (Some(a), ..) => Err(format!("&get expected list or map, got: {}", a)),
-    (None, ..) => Err(format!("&get expected 2 arguments, got: {:?}", xs)),
+    (Some(a), ..) => Err(format!("map &get expected map, got: {}", a)),
+    (None, ..) => Err(format!("map &get expected 2 arguments, got: {:?}", xs)),
   }
 }
 

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -145,26 +145,6 @@ pub fn call_merge(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
-  match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::Nil), _) => Err(String::from("nil includes nothing")),
-    (Some(Calcit::Map(ys)), Some(a)) => {
-      for (_k, v) in ys {
-        if v == a {
-          return Ok(Calcit::Bool(true));
-        }
-      }
-      Ok(Calcit::Bool(false))
-    }
-    (Some(Calcit::List(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains(a))),
-    (Some(Calcit::Set(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains(a))),
-    (Some(Calcit::Str(xs)), Some(Calcit::Str(a))) => Ok(Calcit::Bool(xs.contains(a))),
-    (Some(Calcit::Str(_)), Some(a)) => Err(format!("string `contains?` expected a string, got: {}", a)),
-    (Some(a), ..) => Err(format!("expected list, map, set, got: {}", a)),
-    (None, ..) => Err(format!("expected 2 arguments, got: {:?}", xs)),
-  }
-}
-
 pub fn to_pairs(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     // get a random order from internals
@@ -244,5 +224,20 @@ pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (Some(Calcit::Map(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains_key(a))),
     (Some(a), ..) => Err(format!("map contains? expected a map, got: {}", a)),
     (None, ..) => Err(format!("map contains? expected 2 arguments, got: {:?}", xs)),
+  }
+}
+
+pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Map(ys)), Some(a)) => {
+      for (_k, v) in ys {
+        if v == a {
+          return Ok(Calcit::Bool(true));
+        }
+      }
+      Ok(Calcit::Bool(false))
+    }
+    (Some(a), ..) => Err(format!("map `includes?` expected a map, got: {}", a)),
+    (None, ..) => Err(format!("map `includes?` expected 2 arguments, got: {:?}", xs)),
   }
 }

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -16,53 +16,6 @@ pub fn call_new_map(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
-  match (xs.get(0), xs.get(1), xs.get(2)) {
-    (Some(Calcit::List(xs)), Some(Calcit::Number(n)), Some(a)) => match f64_to_usize(*n) {
-      Ok(idx) => {
-        if idx < xs.len() {
-          let mut ys = xs.clone();
-          ys[idx] = a.clone();
-          Ok(Calcit::List(ys))
-        } else {
-          Ok(Calcit::Nil)
-        }
-      }
-      Err(e) => Err(e),
-    },
-    (Some(Calcit::Tuple(a0, a1)), Some(Calcit::Number(n)), Some(a)) => match f64_to_usize(*n) {
-      Ok(idx) => {
-        if idx == 0 {
-          Ok(Calcit::Tuple(Box::new(a.to_owned()), a1.to_owned()))
-        } else if idx == 1 {
-          Ok(Calcit::Tuple(a0.to_owned(), Box::new(a.to_owned())))
-        } else {
-          Err(format!("Tuple only has fields of 0,1 , unknown index: {}", idx))
-        }
-      }
-      Err(e) => Err(e),
-    },
-    (Some(Calcit::Map(xs)), Some(a), Some(b)) => {
-      let ys = &mut xs.clone();
-      ys.insert(a.clone(), b.clone());
-      Ok(Calcit::Map(ys.clone()))
-    }
-    (Some(Calcit::Record(name, fields, values)), Some(a), Some(b)) => match a {
-      Calcit::Str(s) | Calcit::Keyword(s) | Calcit::Symbol(s, ..) => match find_in_fields(fields, s) {
-        Some(pos) => {
-          let mut new_values = values.clone();
-          new_values[pos] = b.clone();
-          Ok(Calcit::Record(name.clone(), fields.clone(), new_values))
-        }
-        None => Err(format!("invalid field `{}` for {:?}", s, fields)),
-      },
-      a => Err(format!("invalid field `{}` for {:?}", a, fields)),
-    },
-    (Some(a), ..) => Err(format!("assoc expected list or map, got: {}", a)),
-    (None, ..) => Err(format!("assoc expected 3 arguments, got: {:?}", xs)),
-  }
-}
-
 pub fn dissoc(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Map(xs)), Some(a)) => {
@@ -245,5 +198,17 @@ pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
     },
     Some(a) => Err(format!("map:rest expected a map, got: {}", a)),
     None => Err(String::from("map:rest expected 1 argument")),
+  }
+}
+
+pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1), xs.get(2)) {
+    (Some(Calcit::Map(xs)), Some(a), Some(b)) => {
+      let ys = &mut xs.clone();
+      ys.insert(a.clone(), b.clone());
+      Ok(Calcit::Map(ys.clone()))
+    }
+    (Some(a), ..) => Err(format!("map:assoc expected a map, got: {}", a)),
+    (None, ..) => Err(format!("map:assoc expected 3 arguments, got: {:?}", xs)),
   }
 }

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -30,6 +30,18 @@ pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
       }
       Err(e) => Err(e),
     },
+    (Some(Calcit::Tuple(a0, a1)), Some(Calcit::Number(n)), Some(a)) => match f64_to_usize(*n) {
+      Ok(idx) => {
+        if idx == 0 {
+          Ok(Calcit::Tuple(Box::new(a.to_owned()), a1.to_owned()))
+        } else if idx == 1 {
+          Ok(Calcit::Tuple(a0.to_owned(), Box::new(a.to_owned())))
+        } else {
+          Err(format!("Tuple only has fields of 0,1 , unknown index: {}", idx))
+        }
+      }
+      Err(e) => Err(e),
+    },
     (Some(Calcit::Map(xs)), Some(a), Some(b)) => {
       let ys = &mut xs.clone();
       ys.insert(a.clone(), b.clone());

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -213,7 +213,6 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
 pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     Some(Calcit::Map(ys)) => Ok(Calcit::Bool(ys.is_empty())),
-    Some(Calcit::Set(ys)) => Ok(Calcit::Bool(ys.is_empty())),
     Some(a) => Err(format!("map empty? expected some map, got: {}", a)),
     None => Err(String::from("map empty? expected 1 argument")),
   }
@@ -239,5 +238,18 @@ pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     }
     (Some(a), ..) => Err(format!("map `includes?` expected a map, got: {}", a)),
     (None, ..) => Err(format!("map `includes?` expected 2 arguments, got: {:?}", xs)),
+  }
+}
+
+/// use builtin function since maps need to be handled specifically
+pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Map(ys)) => match ys.iter().next() {
+      // TODO order may not be stable enough
+      Some((k, v)) => Ok(Calcit::List(im::vector![k.to_owned(), v.to_owned()])),
+      None => Ok(Calcit::Nil),
+    },
+    Some(a) => Err(format!("map:first expected a map, got: {}", a)),
+    None => Err(String::from("map:first expected 1 argument")),
   }
 }

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -251,3 +251,12 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("map count expected 1 argument")),
   }
 }
+
+pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Map(ys)) => Ok(Calcit::Bool(ys.is_empty())),
+    Some(Calcit::Set(ys)) => Ok(Calcit::Bool(ys.is_empty())),
+    Some(a) => Err(format!("map empty? expected some map, got: {}", a)),
+    None => Err(String::from("map empty? expected 1 argument")),
+  }
+}

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -1,7 +1,7 @@
 use crate::builtins::records::find_in_fields;
 use crate::primes::{Calcit, CalcitItems};
 
-use crate::util::number::{f64_to_usize, is_even};
+use crate::util::number::is_even;
 
 pub fn call_new_map(xs: &CalcitItems) -> Result<Calcit, String> {
   if is_even(xs.len()) {
@@ -23,16 +23,8 @@ pub fn dissoc(xs: &CalcitItems) -> Result<Calcit, String> {
       ys.remove(a);
       Ok(Calcit::Map(ys.clone()))
     }
-    (Some(Calcit::List(xs)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => {
-        let ys = &mut xs.clone();
-        ys.remove(idx);
-        Ok(Calcit::List(ys.clone()))
-      }
-      Err(e) => Err(format!("dissoc expected number, {}", e)),
-    },
-    (Some(a), ..) => Err(format!("dissoc expected a map, got: {}", a)),
-    (_, _) => Err(format!("dissoc expected 2 arguments, got: {:?}", xs)),
+    (Some(a), ..) => Err(format!("map dissoc expected a map, got: {}", a)),
+    (_, _) => Err(format!("map dissoc expected 2 arguments, got: {:?}", xs)),
   }
 }
 

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -118,28 +118,6 @@ pub fn map_get(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
-  match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::List(xs)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => Ok(Calcit::Bool(idx < xs.len())),
-      Err(e) => Err(e),
-    },
-    (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
-      Ok(idx) => Ok(Calcit::Bool(idx < s.chars().count())),
-      Err(e) => Err(e),
-    },
-    (Some(Calcit::Map(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains_key(a))),
-    (Some(Calcit::Record(_name, fields, _)), Some(a)) => match a {
-      Calcit::Str(k) | Calcit::Keyword(k) | Calcit::Symbol(k, ..) => {
-        Ok(Calcit::Bool(find_in_fields(fields, k).is_some()))
-      }
-      a => Err(format!("contains? got invalid field for record: {}", a)),
-    },
-    (Some(a), ..) => Err(format!("contains? expected list or map, got: {}", a)),
-    (None, ..) => Err(format!("contains? expected 2 arguments, got: {:?}", xs)),
-  }
-}
-
 pub fn call_merge(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Map(xs)), Some(Calcit::Map(ys))) => {
@@ -258,5 +236,13 @@ pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     Some(Calcit::Set(ys)) => Ok(Calcit::Bool(ys.is_empty())),
     Some(a) => Err(format!("map empty? expected some map, got: {}", a)),
     None => Err(String::from("map empty? expected 1 argument")),
+  }
+}
+
+pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Map(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains_key(a))),
+    (Some(a), ..) => Err(format!("map contains? expected a map, got: {}", a)),
+    (None, ..) => Err(format!("map contains? expected 2 arguments, got: {:?}", xs)),
   }
 }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -292,3 +292,17 @@ pub fn native_compare(xs: &CalcitItems) -> Result<Calcit, String> {
     (a, b) => Err(format!("&compare expected 2 values, got {:?} {:?}", a, b)),
   }
 }
+
+pub fn tuple_nth(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Tuple(a, b)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(0) => Ok((**a).clone()),
+      Ok(1) => Ok((**b).to_owned()),
+      Ok(m) => Err(format!("Tuple only got 2 elements, trying to index with {}", m)),
+      Err(e) => Err(format!("nth expect usize, {}", e)),
+    },
+    (Some(_), None) => Err(format!("nth expected a tuple and an index, got: {:?}", xs)),
+    (None, Some(_)) => Err(format!("nth expected a tuple and an index, got: {:?}", xs)),
+    (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
+  }
+}

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -204,8 +204,8 @@ pub fn invoke_method(
   invoke_args: &CalcitItems,
   program_code: &program::ProgramCodeData,
 ) -> Result<Calcit, String> {
-  let (class, raw_value) = match invoke_args.get(0) {
-    Some(Calcit::Tuple(a, b)) => ((**a).to_owned(), (**b).to_owned()),
+  let (class, value) = match invoke_args.get(0) {
+    Some(Calcit::Tuple(a, _b)) => ((**a).to_owned(), invoke_args.get(0).unwrap().to_owned()),
     Some(Calcit::Number(..)) => {
       // classed should already be preprocessed
       let code = gen_sym("&core-number-class");
@@ -244,7 +244,7 @@ pub fn invoke_method(
       match find_in_fields(&fields, name) {
         Some(idx) => {
           let mut method_args: im::Vector<Calcit> = im::vector![];
-          method_args.push_back(raw_value.to_owned());
+          method_args.push_back(value.to_owned());
           let mut at_first = true;
           for x in invoke_args {
             if at_first {

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -306,3 +306,22 @@ pub fn tuple_nth(xs: &CalcitItems) -> Result<Calcit, String> {
     (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }
+
+pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1), xs.get(2)) {
+    (Some(Calcit::Tuple(a0, a1)), Some(Calcit::Number(n)), Some(a)) => match f64_to_usize(*n) {
+      Ok(idx) => {
+        if idx == 0 {
+          Ok(Calcit::Tuple(Box::new(a.to_owned()), a1.to_owned()))
+        } else if idx == 1 {
+          Ok(Calcit::Tuple(a0.to_owned(), Box::new(a.to_owned())))
+        } else {
+          Err(format!("Tuple only has fields of 0,1 , unknown index: {}", idx))
+        }
+      }
+      Err(e) => Err(e),
+    },
+    (Some(a), ..) => Err(format!("tuplu:assoc expected a tuple, got: {}", a)),
+    (None, ..) => Err(format!("tuplu:assoc expected 3 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -213,3 +213,21 @@ pub fn get(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("record &get expected 2 arguments, got: {:?}", xs)),
   }
 }
+
+pub fn assoc(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1), xs.get(2)) {
+    (Some(Calcit::Record(name, fields, values)), Some(a), Some(b)) => match a {
+      Calcit::Str(s) | Calcit::Keyword(s) | Calcit::Symbol(s, ..) => match find_in_fields(fields, s) {
+        Some(pos) => {
+          let mut new_values = values.clone();
+          new_values[pos] = b.clone();
+          Ok(Calcit::Record(name.clone(), fields.clone(), new_values))
+        }
+        None => Err(format!("invalid field `{}` for {:?}", s, fields)),
+      },
+      a => Err(format!("invalid field `{}` for {:?}", a, fields)),
+    },
+    (Some(a), ..) => Err(format!("record:assoc expected a record, got: {}", a)),
+    (None, ..) => Err(format!("record:assoc expected 3 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -164,3 +164,16 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("record count expected 1 argument")),
   }
 }
+
+pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Record(_name, fields, _)), Some(a)) => match a {
+      Calcit::Str(k) | Calcit::Keyword(k) | Calcit::Symbol(k, ..) => {
+        Ok(Calcit::Bool(find_in_fields(fields, k).is_some()))
+      }
+      a => Err(format!("contains? got invalid field for record: {}", a)),
+    },
+    (Some(a), ..) => Err(format!("record contains? expected a record, got: {}", a)),
+    (None, ..) => Err(format!("record contains? expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
 use std::ops::Rem;
 
-use crate::primes::{Calcit, CalcitItems};
+use crate::primes::{Calcit, CalcitItems, CrListWrap};
+use crate::util::number::f64_to_usize;
 
 pub fn new_record(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
@@ -175,5 +176,26 @@ pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     },
     (Some(a), ..) => Err(format!("record contains? expected a record, got: {}", a)),
     (None, ..) => Err(format!("record contains? expected 2 arguments, got: {:?}", xs)),
+  }
+}
+
+pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Record(_name, fields, values)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(idx) => {
+        if idx < fields.len() {
+          Ok(Calcit::List(im::vector![
+            Calcit::Keyword(fields[idx].clone()),
+            values[idx].clone()
+          ]))
+        } else {
+          Ok(Calcit::Nil)
+        }
+      }
+      Err(e) => Err(format!("nth expect usize, {}", e)),
+    },
+    (Some(_), None) => Err(format!("record nth expected a record and index, got: {:?}", xs)),
+    (None, Some(_)) => Err(format!("record nth expected a record and index, got: {:?}", xs)),
+    (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -199,3 +199,17 @@ pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
     (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }
+
+pub fn get(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Record(_name, fields, values)), Some(a)) => match a {
+      Calcit::Str(k) | Calcit::Keyword(k) | Calcit::Symbol(k, ..) => match find_in_fields(fields, k) {
+        Some(idx) => Ok(values[idx].clone()),
+        None => Ok(Calcit::Nil),
+      },
+      a => Err(format!("record field expected to be string/keyword, got {}", a)),
+    },
+    (Some(a), ..) => Err(format!("record &get expected record, got: {}", a)),
+    (None, ..) => Err(format!("record &get expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -83,3 +83,11 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("set count expected 1 argument")),
   }
 }
+
+pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Set(ys)) => Ok(Calcit::Bool(ys.is_empty())),
+    Some(a) => Err(format!("set empty? expected some set, got: {}", a)),
+    None => Err(String::from("set empty? expected 1 argument")),
+  }
+}

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -112,3 +112,18 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("set:first expected 1 argument")),
   }
 }
+
+pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Set(ys)) => match ys.iter().next() {
+      Some(y0) => {
+        let mut zs = ys.clone();
+        zs.remove(y0);
+        Ok(Calcit::Set(zs))
+      }
+      None => Ok(Calcit::Nil),
+    },
+    Some(a) => Err(format!("set:rest expected a set, got: {}", a)),
+    None => Err(String::from("set:rest expected 1 argument")),
+  }
+}

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -91,3 +91,11 @@ pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("set empty? expected 1 argument")),
   }
 }
+
+pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Set(xs)), Some(a)) => Ok(Calcit::Bool(xs.contains(a))),
+    (Some(a), ..) => Err(format!("sets `includes?` expected set, got: {}", a)),
+    (None, ..) => Err(format!("sets `includes?` expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -99,3 +99,16 @@ pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("sets `includes?` expected 2 arguments, got: {:?}", xs)),
   }
 }
+
+/// use builtin function since sets need to be handled specifically
+pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Set(ys)) => match ys.iter().next() {
+      // TODO first element of a set.. need to be more sure...
+      Some(v) => Ok(v.clone()),
+      None => Ok(Calcit::Nil),
+    },
+    Some(a) => Err(format!("set:first expected a set, got: {}", a)),
+    None => Err(String::from("set:first expected 1 argument")),
+  }
+}

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -234,3 +234,14 @@ pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("string empty? expected 1 argument")),
   }
 }
+
+pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(idx) => Ok(Calcit::Bool(idx < s.chars().count())),
+      Err(e) => Err(e),
+    },
+    (Some(a), ..) => Err(format!("strings contains? expected a string, got: {}", a)),
+    (None, ..) => Err(format!("strings contains? expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -226,3 +226,11 @@ pub fn count(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("string count expected 1 argument")),
   }
 }
+
+pub fn empty_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Str(s)) => Ok(Calcit::Bool(s.is_empty())),
+    Some(a) => Err(format!("string empty? expected a string, got: {}", a)),
+    None => Err(String::from("string empty? expected 1 argument")),
+  }
+}

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -245,3 +245,12 @@ pub fn contains_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (None, ..) => Err(format!("strings contains? expected 2 arguments, got: {:?}", xs)),
   }
 }
+
+pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Str(xs)), Some(Calcit::Str(a))) => Ok(Calcit::Bool(xs.contains(a))),
+    (Some(Calcit::Str(_)), Some(a)) => Err(format!("string `includes?` expected a string, got: {}", a)),
+    (Some(a), ..) => Err(format!("string `includes?` expected string, got: {}", a)),
+    (None, ..) => Err(format!("string `includes?` expected 2 arguments, got: {:?}", xs)),
+  }
+}

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -279,3 +279,22 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
     None => Err(String::from("str:first expected 1 argument")),
   }
 }
+
+pub fn rest(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Str(s)) => {
+      let mut buffer = String::from("");
+      let mut is_first = true;
+      for c in s.chars() {
+        if is_first {
+          is_first = false;
+          continue;
+        }
+        buffer.push(c)
+      }
+      Ok(Calcit::Str(buffer.to_owned()))
+    }
+    Some(a) => Err(format!("str:rest expected a string, got: {}", a)),
+    None => Err(String::from("str:rest expected 1 argument")),
+  }
+}

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use crate::primes;
-use crate::primes::{Calcit, CalcitItems};
+use crate::primes::{Calcit, CalcitItems, CrListWrap};
 use crate::util::number::f64_to_usize;
 
 pub fn binary_str_concat(xs: &CalcitItems) -> Result<Calcit, String> {
@@ -252,5 +252,19 @@ pub fn includes_ques(xs: &CalcitItems) -> Result<Calcit, String> {
     (Some(Calcit::Str(_)), Some(a)) => Err(format!("string `includes?` expected a string, got: {}", a)),
     (Some(a), ..) => Err(format!("string `includes?` expected string, got: {}", a)),
     (None, ..) => Err(format!("string `includes?` expected 2 arguments, got: {:?}", xs)),
+  }
+}
+pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
+  match (xs.get(0), xs.get(1)) {
+    (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
+      Ok(idx) => match s.chars().nth(idx) {
+        Some(v) => Ok(Calcit::Str(v.to_string())),
+        None => Ok(Calcit::Nil),
+      },
+      Err(e) => Err(format!("nth expect usize, {}", e)),
+    },
+    (Some(_), None) => Err(format!("string nth expected a string and index, got: {:?}", xs)),
+    (None, Some(_)) => Err(format!("string nth expected a string and index, got: {:?}", xs)),
+    (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -268,3 +268,14 @@ pub fn nth(xs: &CalcitItems) -> Result<Calcit, String> {
     (_, _) => Err(format!("nth expected 2 argument, got: {}", CrListWrap(xs.to_owned()))),
   }
 }
+
+pub fn first(xs: &CalcitItems) -> Result<Calcit, String> {
+  match xs.get(0) {
+    Some(Calcit::Str(s)) => match s.chars().next() {
+      Some(c) => Ok(Calcit::Str(c.to_string())),
+      None => Ok(Calcit::Nil),
+    },
+    Some(a) => Err(format!("str:first expected a string, got: {}", a)),
+    None => Err(String::from("str:first expected 1 argument")),
+  }
+}

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1230,7 +1230,7 @@
             :assoc &map:assoc
             :contains? &map:contains?
             :count &map:count
-            :dissoc dissoc
+            :dissoc &map:dissoc
             :empty $ defn &map:empty (x) (&{})
             :empty? &map:empty?
             :get &map:get
@@ -1305,6 +1305,7 @@
             :zipmap zipmap
             :first &list:first
             :rest &list:rest
+            :dissoc &list:dissoc
 
         |&init-builtin-classes! $ quote
           defn &init-builtin-classes! ()
@@ -1368,3 +1369,9 @@
               if (tuple? x) (&tuple:assoc x k v)
                 if (list? x) (&list:assoc x k v)
                   .assoc x k v
+
+        |dissoc $ quote
+          defn dissoc (x k)
+            if (nil? x) nil
+              if (list? x) (&list:dissoc x k)
+                .dissoc x k

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1204,6 +1204,7 @@
             :strip-suffix strip-suffix
             :substr substr
             :trim trim
+            :empty? &str:empty?
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1212,7 +1213,7 @@
             :difference difference
             :exclude exclude
             :empty empty
-            :empty? empty?
+            :empty? &set:empty?
             :include include
             :includes? includes?
             :intersection intersection
@@ -1226,7 +1227,7 @@
             :count &map:count
             :dissoc dissoc
             :empty empty
-            :empty? empty?
+            :empty? &map:empty?
             :get &get
             :get-in get-in
             :includes? includes?
@@ -1262,7 +1263,7 @@
             :drop drop
             :each each
             :empty empty
-            :empty? empty?
+            :empty? &list:empty?
             :filter filter
             :filter-not filter-not
             :find-index find-index
@@ -1309,3 +1310,10 @@
                 if (list? x)
                   &list:count x
                   .count x
+
+        |empty? $ quote
+          defn empty? (x)
+            if (nil? x) true
+              if (list? x)
+                &list:empty? x
+                .empty? x

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1227,7 +1227,7 @@
 
         |&core-map-class $ quote
           defrecord! &core-map-class
-            :assoc assoc
+            :assoc &map:assoc
             :contains? &map:contains?
             :count &map:count
             :dissoc dissoc
@@ -1257,13 +1257,14 @@
             :count &record:count
             :contains? &record:contains?
             :nth &record:nth
+            :assoc &record:assoc
 
         |&core-list-class $ quote
           defrecord! &core-list-class
             :any? any?
             :add coll-append
             :append append
-            :assoc assoc
+            :assoc &list:assoc
             :assoc-after assoc-after
             :assoc-before assoc-before
             :butlast butlast
@@ -1295,7 +1296,6 @@
             :pairs-map pairs-map
             :prepend prepend
             :reduce reduce
-            :rest rest
             :reverse reverse
             :section-by section-by
             :slice slice
@@ -1361,3 +1361,10 @@
             if (nil? x) nil
               if (list? x) (&list:rest x)
                 .rest x
+
+        |assoc $ quote
+          defn assoc (x k v)
+            if (nil? x) (raise "|assoc does not work on nil")
+              if (tuple? x) (&tuple:assoc x k v)
+                if (list? x) (&list:assoc x k v)
+                  .assoc x k v

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -324,7 +324,7 @@
                                 let
                                   ~ $ map-indexed (&list:rest pattern) $ fn (idx x)
                                     [] x $ quasiquote
-                                      nth ~v# (~ (inc idx))
+                                      &list:nth ~v# (~ (inc idx))
                                   , ~branch
                                 key-match ~value (~@ (&list:rest body))
 
@@ -364,9 +364,9 @@
           defn get (base k)
             cond
               (nil? base) nil
-              (string? base) (nth base k)
+              (string? base) (&str:nth base k)
               (map? base) (&map:get base k)
-              (list? base) (nth base k)
+              (list? base) (&list:nth base k)
               (record? base) (&record:get base k)
               true $ &let nil
                 echo "|Value:" base k
@@ -793,7 +793,7 @@
             if (&= 1 (&list:count pairs))
               quote-replace
                 &let
-                  ~ $ nth pairs 0
+                  ~ $ &list:nth pairs 0
                   ~@ body
               if (&list:empty? pairs)
                 quote-replace $ &let nil ~@body
@@ -1146,10 +1146,10 @@
             assert "|method by string or keyword"
               or (string? name) (keyword? name) (symbol? name)
             let
-                proto $ nth pair 0
+                proto $ &tuple:nth pair 0
                 f $ &record:get proto name
               assert "|expected function" (fn? f)
-              f (nth pair 1) & params
+              f (&list:nth pair 1) & params
 
         |&list-sort-by $ quote
           defn &list-sort-by (xs f)
@@ -1355,7 +1355,7 @@
                 .nth x i
 
         |first $ quote
-          defn nth (x)
+          defn first (x)
             if (nil? x) nil
               if (tuple? x) (&tuple:nth x 0)
                 if (list? x) (&list:nth x 0)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -443,25 +443,28 @@
           defn filter (xs f)
             foldl xs (empty xs)
               fn (acc x)
-                if (f x) (coll-append acc x) acc
+                if (f x) (&coll-append acc x) acc
 
         |filter-not $ quote
           defn filter-not (xs f)
             reduce xs (empty xs)
               fn (acc x)
-                if-not (f x) (coll-append acc x) acc
+                if-not (f x) (&coll-append acc x) acc
 
-        |coll-append $ quote
-          defn coll-append (xs a)
+        |&coll-append $ quote
+          defn &coll-append (xs a)
             if (list? xs) (append xs a)
               if (set? xs) (&include xs a)
                 if (map? xs)
-                  &let nil
-                    assert "|coll-append to map expected a pair" $ and (list? a)
-                      &= 2 (count a)
-                    let[] (k v) a
-                      assoc xs k v
-                  raise "|coll-append expected a collection"
+                  &map:add-entry xs a
+                  raise "|&coll-append expected a collection"
+
+        |&map:add-entry $ quote
+          defn &map:add-entry (xs pair)
+            assert "|&map:add-entry expected value in a pair" $ and (list? pair)
+              &= 2 (count pair)
+            let[] (k v) pair
+              assoc xs k v
 
         |empty $ quote
           defn empty (x)
@@ -1211,7 +1214,7 @@
 
         |&core-set-class $ quote
           defrecord! &core-set-class
-            :add coll-append
+            :add include
             :count &set:count
             :difference difference
             :exclude exclude
@@ -1227,6 +1230,7 @@
 
         |&core-map-class $ quote
           defrecord! &core-map-class
+            :add &map:add-entry
             :assoc &map:assoc
             :contains? &map:contains?
             :count &map:count
@@ -1262,7 +1266,7 @@
         |&core-list-class $ quote
           defrecord! &core-list-class
             :any? any?
-            :add coll-append
+            :add append
             :append append
             :assoc &list:assoc
             :assoc-after assoc-after

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -44,7 +44,7 @@
 
         |- $ quote
           defn - (x & ys)
-            if (empty? ys)
+            if (&list:empty? ys)
               &- 0 x
               reduce ys x &-
 
@@ -53,55 +53,55 @@
 
         |/ $ quote
           defn / (x & ys)
-            if (empty? ys)
+            if (&list:empty? ys)
               &/ 1 x
               reduce ys x &/
 
         |foldl-compare $ quote
           defn foldl-compare (xs acc f)
-            if (empty? xs) true
-              if (f acc (first xs))
-                recur (rest xs) (first xs) f
+            if (&list:empty? xs) true
+              if (f acc (&list:first xs))
+                recur (&list:rest xs) (&list:first xs) f
                 , false
 
         |foldl' $ quote
           defn foldl' (xs acc f)
-            if (empty? xs) acc
-              recur (rest xs) (f acc (first xs)) f
+            if (&list:empty? xs) acc
+              recur (&list:rest xs) (f acc (&list:first xs)) f
 
         |< $ quote
           defn < (x & ys)
             if
-              &= 1 (count ys)
-              &< x (first ys)
+              &= 1 (&list:count ys)
+              &< x (&list:first ys)
               foldl-compare ys x &<
 
         |> $ quote
           defn > (x & ys)
             if
-              &= 1 (count ys)
-              &> x (first ys)
+              &= 1 (&list:count ys)
+              &> x (&list:first ys)
               foldl-compare ys x &>
 
         |= $ quote
           defn = (x & ys)
             if
-              &= 1 (count ys)
-              &= x (first ys)
+              &= 1 (&list:count ys)
+              &= x (&list:first ys)
               foldl-compare ys x &=
 
         |>= $ quote
           defn >= (x & ys)
             if
-              &= 1 (count ys)
-              &>= x (first ys)
+              &= 1 (&list:count ys)
+              &>= x (&list:first ys)
               foldl-compare ys x &>=
 
         |<= $ quote
           defn <= (x & ys)
             if
-              &= 1 (count ys)
-              &<= x (first ys)
+              &= 1 (&list:count ys)
+              &<= x (&list:first ys)
               foldl-compare ys x &<=
 
         |apply $ quote
@@ -109,9 +109,9 @@
 
         |apply-args $ quote
           defmacro apply-args (args f)
-            if (&= '[] (first args))
+            if (&= '[] (&list:first args))
               quasiquote
-                ~f (~@ (rest args))
+                ~f (~@ (&list:rest args))
               quasiquote
                 ~f ~@args
 
@@ -181,7 +181,7 @@
                     &let
                       result (f $ [] k v)
                       assert "|expected pair returned when mapping hashmap"
-                        and (list? result) (&= 2 (count result))
+                        and (list? result) (&= 2 (&list:count result))
                       let[] (k2 v2) result
                         assoc acc k2 v2
               true
@@ -191,16 +191,16 @@
 
         |take $ quote
           defn take (xs n)
-            if (= n (count xs)) xs
+            if (= n (&list:count xs)) xs
               slice xs 0 n
 
         |drop $ quote
           defn drop (xs n)
-            slice xs n (count xs)
+            slice xs n (&list:count xs)
 
         |str $ quote
           defmacro str (x0 & xs)
-            if (empty? xs)
+            if (&list:empty? xs)
               quote-replace $ &str ~x0
               quote-replace $ &str-concat ~x0 $ str ~@xs
 
@@ -252,29 +252,29 @@
 
         |-> $ quote
           defmacro -> (base & xs)
-            if (empty? xs)
+            if (&list:empty? xs)
               quote-replace ~base
               &let
-                x0 (first xs)
+                x0 (&list:first xs)
                 if (list? x0)
                   recur
-                    concat ([] (first x0) base) (rest x0)
-                    , & (rest xs)
-                  recur ([] x0 base) & (rest xs)
+                    concat ([] (&list:first x0) base) (&list:rest x0)
+                    , & (&list:rest xs)
+                  recur ([] x0 base) & (&list:rest xs)
 
         |->> $ quote
           defmacro ->> (base & xs)
-            if (empty? xs)
+            if (&list:empty? xs)
               quote-replace ~base
               &let
-                x0 (first xs)
+                x0 (&list:first xs)
                 if (list? x0)
-                  recur (append x0 base) & (rest xs)
-                  recur ([] x0 base) & (rest xs)
+                  recur (append x0 base) & (&list:rest xs)
+                  recur ([] x0 base) & (&list:rest xs)
 
         |->% $ quote
           defmacro ->% (base & xs)
-            if (empty? xs) base
+            if (&list:empty? xs) base
               let
                   tail $ last xs
                   pairs $ concat
@@ -288,56 +288,56 @@
         |cond $ quote
           defmacro cond (pair & else)
             assert "|expects a pair"
-              if (list? pair) (&= 2 (count pair)) false
+              if (list? pair) (&= 2 (&list:count pair)) false
             &let
-              expr $ nth pair 0
+              expr $ &list:nth pair 0
               &let
-                branch $ nth pair 1
+                branch $ &list:nth pair 1
                 quote-replace
                   if ~expr ~branch
-                    ~ $ if (empty? else) nil
+                    ~ $ if (&list:empty? else) nil
                       quote-replace
                         cond
-                          ~ $ nth else 0
-                          ~@ $ rest else
+                          ~ $ &list:nth else 0
+                          ~@ $ &list:rest else
 
         |key-match $ quote
           defmacro key-match (value & body)
-            if (empty? body)
+            if (&list:empty? body)
               quasiquote
                 &let nil
                   echo "|[warn] key-match found no matched case, missing `_` case?" ~value
               &let
-                pair (first body)
+                pair (&list:first body)
                 assert "|key-match expected pairs"
-                  and (list? pair) (&= 2 (count pair))
+                  and (list? pair) (&= 2 (&list:count pair))
                 let[] (pattern branch) pair
                   if (&= pattern '_) branch
                     &let nil
                       assert "|pattern in a list" (list? pattern)
                       &let
-                        k (first pattern)
+                        k (&list:first pattern)
                         &let (v# (gensym 'v))
                           quasiquote
                             &let (~v# ~value)
-                              if (&= (first ~v#) ~k)
+                              if (&= (&list:first ~v#) ~k)
                                 let
-                                  ~ $ map-indexed (rest pattern) $ fn (idx x)
+                                  ~ $ map-indexed (&list:rest pattern) $ fn (idx x)
                                     [] x $ quasiquote
                                       nth ~v# (~ (inc idx))
                                   , ~branch
-                                key-match ~value (~@ (rest body))
+                                key-match ~value (~@ (&list:rest body))
 
         |&case $ quote
           defmacro &case (item default pattern & others)
             assert "|`case` expects pattern in a pair"
-              if (list? pattern) (&= 2 (count pattern)) false
+              if (list? pattern) (&= 2 (&list:count pattern)) false
             let
-                x $ first pattern
+                x $ &list:first pattern
                 branch $ last pattern
               quote-replace
                 if (&= ~item ~x) ~branch
-                  ~ $ if (empty? others) default
+                  ~ $ if (&list:empty? others) default
                     quote-replace
                       &case ~item ~default ~@others
 
@@ -352,7 +352,7 @@
 
         |case-default $ quote
           defmacro case (item default & patterns)
-            if (empty? patterns)
+            if (&list:empty? patterns)
               raise "|Expected patterns for case-default, got empty"
             &let
               v (gensym |v)
@@ -377,10 +377,10 @@
             assert "|expects path in a list" (list? path)
             cond
               (nil? base) nil
-              (empty? path) base
+              (&list:empty? path) base
               true
                 recur
-                  get base (first path)
+                  get base (&list:first path)
                   rest path
 
         |&max $ quote
@@ -395,14 +395,14 @@
 
         |max $ quote
           defn max (xs)
-            if (empty? xs) nil
-              reduce (rest xs) (first xs)
+            if (&list:empty? xs) nil
+              reduce (&list:rest xs) (&list:first xs)
                 fn (acc x) (&max acc x)
 
         |min $ quote
           defn min (xs)
-            if (empty? xs) nil
-              reduce (rest xs) (first xs)
+            if (&list:empty? xs) nil
+              reduce (&list:rest xs) (&list:first xs)
                 fn (acc x) (&min acc x)
 
         |every? $ quote
@@ -475,9 +475,9 @@
               fn (acc pair)
                 assert "|expects pair for pairs-map"
                   if (list? pair)
-                    &= 2 (count pair)
+                    &= 2 (&list:count pair)
                     , false
-                assoc acc (first pair) (last pair)
+                assoc acc (&list:first pair) (last pair)
 
         |some? $ quote
           defn some? (x) $ not $ nil? x
@@ -485,15 +485,15 @@
         |some-in? $ quote
           defn some-in? (x path)
             if (nil? x) false
-              if (empty? path) true
-                &let (k $ first path)
+              if (&list:empty? path) true
+                &let (k $ &list:first path)
                   if (map? x)
                     if (contains? x k)
-                      recur (get x k) (rest path)
+                      recur (get x k) (&list:rest path)
                       , false
                     if (list? x)
                       if (number? k)
-                        recur (get x k) (rest path)
+                        recur (get x k) (&list:rest path)
                         , false
                       raise $ &str-concat "|Unknown structure for some-in? detection: " x
 
@@ -504,28 +504,28 @@
               ({}) xs0 ys0
               fn (acc xs ys)
                 if
-                  if (empty? xs) true (empty? ys)
+                  if (&list:empty? xs) true (&list:empty? ys)
                   , acc
                   recur
-                    assoc acc (first xs) (first ys)
+                    assoc acc (&list:first xs) (&list:first ys)
                     rest xs
                     rest ys
 
         |rand-nth $ quote
           defn rand-nth (xs)
-            if (empty? xs) nil
-              get xs $ rand-int $ &- (count xs) 1
+            if (&list:empty? xs) nil
+              get xs $ rand-int $ &- (&list:count xs) 1
 
         |contains-symbol? $ quote
           defn contains-symbol? (xs y)
             if (list? xs)
               apply-args (xs)
                 fn (body)
-                  if (empty? body) false
+                  if (&list:empty? body) false
                     if
-                      contains-symbol? (first body) y
+                      contains-symbol? (&list:first body) y
                       , true
-                      recur (rest body)
+                      recur (&list:rest body)
               &= xs y
 
         |\ $ quote
@@ -537,12 +537,12 @@
             &let
               args $ ->% (turn-string args-alias) (split % |.) (map % turn-symbol)
               &let
-                inner-body $ if (&= 1 (count xs)) (first xs)
+                inner-body $ if (&= 1 (&list:count xs)) (&list:first xs)
                   quasiquote
                     &let nil ~@xs
                 apply-args (inner-body args)
                   fn (body ys)
-                    if (empty? ys)
+                    if (&list:empty? ys)
                       quote-replace ~body
                       &let
                         a0 (last ys)
@@ -558,7 +558,7 @@
             assert "|expects list key to be an integer" (&= idx (floor idx))
             if
               &> idx 0
-              &< idx (count xs)
+              &< idx (&list:count xs)
               , false
 
         |update $ quote
@@ -588,9 +588,9 @@
             apply-args
               ({}) xs0
               fn (acc xs)
-                if (empty? xs) acc
+                if (&list:empty? xs) acc
                   let
-                      x0 $ first xs
+                      x0 $ &list:first xs
                       key $ f x0
                     recur
                       if (contains? acc key)
@@ -600,19 +600,19 @@
 
         |keys $ quote
           defn keys (x)
-            map (to-pairs x) first
+            map (to-pairs x) &list:first
 
         |keys-non-nil $ quote
           defn keys-non-nil (x)
             apply-args
               (#{}) (to-pairs x)
               fn (acc pairs)
-                if (empty? pairs) acc
+                if (&set:empty? pairs) acc
                   &let
-                    pair $ first pairs
+                    pair $ &set:first pairs
                     if (nil? (last pair))
-                      recur acc (rest pairs)
-                      recur (include acc (first pair))
+                      recur acc (&set:rest pairs)
+                      recur (include acc (&list:first pair))
                         rest pairs
 
         |vals $ quote
@@ -626,12 +626,12 @@
               ({}) xs0
               fn (acc xs)
                 &let
-                  x0 (first xs)
-                  if (empty? xs) acc
+                  x0 (&list:first xs)
+                  if (&list:empty? xs) acc
                     recur
-                      if (contains? acc (first xs))
-                        update acc (first xs) (\ &+ % 1)
-                        assoc acc (first xs) 1
+                      if (contains? acc (&list:first xs))
+                        update acc (&list:first xs) (\ &+ % 1)
+                        assoc acc (&list:first xs) 1
                       rest xs
 
         |section-by $ quote
@@ -640,8 +640,8 @@
               apply-args
                 ([]) xs0
                 fn (acc xs)
-                  if (&<= (count xs) n)
-                    if (empty? xs) acc
+                  if (&<= (&list:count xs) n)
+                    if (&list:empty? xs) acc
                       append acc xs
                     recur
                       append acc (take xs n)
@@ -719,9 +719,9 @@
 
         |assoc-in $ quote
           defn assoc-in (data path v)
-            if (empty? path) v
+            if (&list:empty? path) v
               let
-                  p0 $ first path
+                  p0 $ &list:first path
                   d $ either data $ &{}
                 assoc d p0
                   assoc-in
@@ -731,24 +731,24 @@
 
         |update-in $ quote
           defn update-in (data path f)
-            if (empty? path)
+            if (&list:empty? path)
               f data
               &let
-                p0 $ first path
+                p0 $ &list:first path
                 assoc data p0
-                  update-in (get data p0) (rest path) f
+                  update-in (get data p0) (&list:rest path) f
 
         |dissoc-in $ quote
           defn dissoc-in (data path)
             cond
-              (empty? path) nil
-              (&= 1 (count path))
-                dissoc data (first path)
+              (&list:empty? path) nil
+              (&= 1 (&list:count path))
+                dissoc data (&list:first path)
               true
                 &let
-                  p0 $ first path
+                  p0 $ &list:first path
                   assoc data p0
-                    dissoc-in (get data p0) (rest path)
+                    dissoc-in (get data p0) (&list:rest path)
 
         |inc $ quote
           defn inc (x) $ &+ x 1
@@ -763,7 +763,7 @@
         |ends-with? $ quote
           defn ends-with? (x y)
             &=
-              &- (count x) (count y)
+              &- (&str:count x) (&str:count y)
               str-find x y
 
         |loop $ quote
@@ -773,10 +773,10 @@
               every? pairs
                 defn detect-pairs? (x)
                   if (list? x)
-                    &= 2 (count x)
+                    &= 2 (&list:count x)
                     , false
             let
-                args $ map pairs first
+                args $ map pairs &list:first
                 values $ map pairs last
               assert "|loop requires symbols in pairs" (every? args symbol?)
               quote-replace
@@ -787,36 +787,36 @@
         |let $ quote
           defmacro let (pairs & body)
             assert "|expects pairs in list for let" (list? pairs)
-            if (&= 1 (count pairs))
+            if (&= 1 (&list:count pairs))
               quote-replace
                 &let
                   ~ $ nth pairs 0
                   ~@ body
-              if (empty? pairs)
+              if (&list:empty? pairs)
                 quote-replace $ &let nil ~@body
                 quote-replace
                   &let
-                    ~ $ nth pairs 0
+                    ~ $ &list:nth pairs 0
                     let
-                      ~ $ rest pairs
+                      ~ $ &list:rest pairs
                       ~@ body
 
         |let-sugar $ quote
           defmacro let-sugar (pairs & body)
             assert "|expects pairs in list for let" (list? pairs)
-            if (empty? pairs)
+            if (&list:empty? pairs)
               quote-replace $ &let nil ~@body
               &let
-                pair $ first pairs
-                assert "|expected pair length of 2" (&= 2 (count pair))
-                if (&= 1 (count pairs))
+                pair $ &list:first pairs
+                assert "|expected pair length of 2" (&= 2 (&list:count pair))
+                if (&= 1 (&list:count pairs))
                   quote-replace
                     let-destruct ~@pair
                       ~@ body
                   quote-replace
                     let-destruct ~@pair
                       let-sugar
-                        ~ $ rest pairs
+                        ~ $ &list:rest pairs
                         ~@ body
 
         |let-destruct $ quote
@@ -825,12 +825,12 @@
               quote-replace
                 &let (~pattern ~v) ~@body
               if (list? pattern)
-                if (&= '[] (first pattern))
+                if (&= '[] (&list:first pattern))
                   quote-replace
-                    let[] (~ (rest pattern)) ~v ~@body
-                  if (&= '{} (first pattern))
+                    let[] (~ (&list:rest pattern)) ~v ~@body
+                  if (&= '{} (&list:first pattern))
                     quote-replace
-                      let{} (~ (rest pattern)) ~v ~@body
+                      let{} (~ (&list:rest pattern)) ~v ~@body
                     &let nil
                       echo pattern
                       raise "|Unknown pattern to destruct"
@@ -862,12 +862,12 @@
           defn join-str (xs0 sep)
             apply-args (| xs0 true)
               fn (acc xs beginning?)
-                if (empty? xs) acc
+                if (&list:empty? xs) acc
                   recur
                     &str-concat
                       if beginning? acc $ &str-concat acc sep
-                      first xs
-                    rest xs
+                      &list:first xs
+                    &list:rest xs
                     , false
 
         |join $ quote
@@ -875,12 +875,12 @@
             apply-args
               ([]) xs0 true
               fn (acc xs beginning?)
-                if (empty? xs) acc
+                if (&list:empty? xs) acc
                   recur
                     append
                       if beginning? acc (append acc sep)
-                      first xs
-                    rest xs
+                      &list:first xs
+                    &list:rest xs
                     , false
 
         |repeat $ quote
@@ -897,10 +897,10 @@
               ([]) xs0 ys0
               fn (acc xs ys)
                 if
-                  if (empty? xs) true (empty? ys)
+                  if (&list:empty? xs) true (&list:empty? ys)
                   , acc
                   recur
-                    -> acc (append (first xs)) (append (first ys))
+                    -> acc (append (&list:first xs)) (append (&list:first ys))
                     rest xs
                     rest ys
 
@@ -912,7 +912,7 @@
                 &let
                   result (f k v)
                   assert "|expected pair returned when mapping hashmap"
-                    and (list? result) (&= 2 (count result))
+                    and (list? result) (&= 2 (&list:count result))
                   let[] (k2 v2) result
                     assoc acc k2 v2
 
@@ -925,28 +925,28 @@
 
         |and $ quote
           defmacro and (item & xs)
-            if (empty? xs)
+            if (&list:empty? xs)
               quote-replace
                 if ~item ~item false
               quote-replace
                 if ~item
                   and
-                    ~ $ first xs
-                    ~@ $ rest xs
+                    ~ $ &list:first xs
+                    ~@ $ &list:rest xs
                   , false
 
         |or $ quote
           defmacro or (item & xs)
-            if (empty? xs) item
+            if (&list:empty? xs) item
               quote-replace
                 if (nil? ~item)
                   or
-                    ~ $ first xs
-                    ~@ $ rest xs
+                    ~ $ &list:first xs
+                    ~@ $ &list:rest xs
                   if (= false ~item)
                     or
-                      ~ $ first xs
-                      ~@ $ rest xs
+                      ~ $ &list:first xs
+                      ~@ $ &list:rest xs
                     ~ item
 
         |with-log $ quote
@@ -980,9 +980,9 @@
         |&doseq $ quote
           defmacro &doseq (pair & body)
             assert "|doseq expects a pair"
-              if (list? pair) (&= 2 (count pair)) false
+              if (list? pair) (&= 2 (&list:count pair)) false
             let
-                name $ first pair
+                name $ &list:first pair
                 xs0 $ last pair
               quote-replace
                 foldl ~xs0 nil $ defn doseq-fn% (_acc ~name) ~@body
@@ -1062,17 +1062,17 @@
                 defs $ apply-args
                   [] ([]) vars 0
                   defn let[]% (acc xs idx)
-                    if (empty? xs) acc
+                    if (&list:empty? xs) acc
                       &let nil
                         when-not
-                          symbol? (first xs)
-                          raise $ &str-concat "|Expected symbol for vars: " (first xs)
-                        if (&= (first xs) '&)
+                          symbol? (&list:first xs)
+                          raise $ &str-concat "|Expected symbol for vars: " (&list:first xs)
+                        if (&= (&list:first xs) '&)
                           &let nil
-                            assert "|expected list spreading" (&= 2 (count xs))
-                            conj acc $ [] (get xs 1) (quote-replace (slice ~v ~idx))
+                            assert "|expected list spreading" (&= 2 (&list:count xs))
+                            conj acc $ [] (&list:nth xs 1) (quote-replace (slice ~v ~idx))
                           recur
-                            conj acc $ [] (first xs) (quote-replace (get ~v ~idx))
+                            conj acc $ [] (&list:first xs) (quote-replace (&list:nth ~v ~idx))
                             rest xs
                             inc idx
               quote-replace
@@ -1090,7 +1090,7 @@
         |defrecord! $ quote
           defmacro defrecord! (name & pairs)
             quasiquote
-              %{} (new-record (quote ~name) (~@ (map pairs first))) ~@pairs
+              %{} (new-record (quote ~name) (~@ (map pairs &list:first))) ~@pairs
 
         |;nil $ quote
           defmacro ;nil (& _body) nil
@@ -1098,13 +1098,13 @@
         |strip-prefix $ quote
           defn strip-prefix (s piece)
             if (starts-with? s piece)
-              substr s (count piece)
+              substr s (&str:count piece)
               , s
 
         |strip-suffix $ quote
           defn strip-suffix (s piece)
             if (ends-with? s piece)
-              substr s 0 (&- (count s) (count piece))
+              substr s 0 (&- (&str:count s) (&str:count piece))
               , s
 
         |select-keys $ quote
@@ -1139,7 +1139,7 @@
         |invoke $ quote
           defn invoke (pair name & params)
             assert "|method! applies on a pair, leading a record"
-              and (list? pair) (= 2 (count pair)) (record? (first pair))
+              and (list? pair) (= 2 (&list:count pair)) (record? (&list:first pair))
             assert "|method by string or keyword"
               or (string? name) (keyword? name) (symbol? name)
             let

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -28,7 +28,7 @@
         |last $ quote
           defn last (xs)
             if (empty? xs) nil
-              &get xs
+              nth xs
                 &- (count xs) 1
 
         |when $ quote
@@ -365,9 +365,9 @@
             cond
               (nil? base) nil
               (string? base) (nth base k)
-              (map? base) (&get base k)
+              (map? base) (&map:get base k)
               (list? base) (nth base k)
-              (record? base) (&get base k)
+              (record? base) (&record:get base k)
               true $ &let nil
                 echo "|Value:" base k
                 raise "|Expected map or list for get"
@@ -574,11 +574,11 @@
                   raise $ &str-concat "|tuple only has 0,1 fields, unknown field: " k
               (map? x)
                 if (contains? x k)
-                  assoc x k $ f (&get x k)
+                  assoc x k $ f (&map:get x k)
                   , x
               (record? x)
                 if (contains? x k)
-                  assoc x k $ f (&get x k)
+                  assoc x k $ f (&record:get x k)
                   , x
               true
                 raise $ &str-concat "|Cannot update key on item: " x
@@ -1111,7 +1111,7 @@
           defn select-keys (m xs)
             assert "|expectd map for selecting" $ map? m
             foldl xs (&{}) $ fn (acc k)
-              assoc acc k (&get m k)
+              assoc acc k (&map:get m k)
 
         |unselect-keys $ quote
           defn unselect-keys (m xs)
@@ -1144,7 +1144,7 @@
               or (string? name) (keyword? name) (symbol? name)
             let
                 proto $ nth pair 0
-                f $ &get proto name
+                f $ &record:get proto name
               assert "|expected function" (fn? f)
               f (nth pair 1) & params
 
@@ -1152,7 +1152,7 @@
           defn &list-sort-by (xs f)
             if (keyword? f)
               sort xs $ fn (a b)
-                &compare (&get a f) (&get b f)
+                &compare (get a f) (get b f)
 
               sort xs $ fn (a b)
                 &compare (f a) (f b)
@@ -1233,7 +1233,7 @@
             :dissoc dissoc
             :empty $ defn &map:empty (x) (&{})
             :empty? &map:empty?
-            :get &get
+            :get &map:get
             :get-in get-in
             :includes? &map:includes?
             :keys keys
@@ -1250,7 +1250,7 @@
 
         |&core-record-class $ quote
           defrecord! &core-record-class
-            :get &get
+            :get &map:get
             :get-name get-record-name
             :same-kind? relevant-record?
             :turn-map turn-map
@@ -1355,7 +1355,7 @@
               if (tuple? x) (&tuple:nth x 0)
                 if (list? x) (&list:nth x 0)
                   .first x
-         
+
         |rest $ quote
           defn rest (x)
             if (nil? x) nil

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1203,6 +1203,7 @@
             :substr substr
             :trim trim
             :empty? &str:empty?
+            :contains? &str:contains?
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1217,11 +1218,12 @@
             :intersection intersection
             :to-list set->list
             :union union
+            :includes? includes?
 
         |&core-map-class $ quote
           defrecord! &core-map-class
             :assoc assoc
-            :contains? contains?
+            :contains? &map:contains?
             :count &map:count
             :dissoc dissoc
             :empty $ defn &map:empty (x) (&{})
@@ -1246,6 +1248,7 @@
             :same-kind? relevant-record?
             :turn-map turn-map
             :count &record:count
+            :contains? &record:contains?
 
         |&core-list-class $ quote
           defrecord! &core-list-class
@@ -1257,6 +1260,7 @@
             :assoc-before assoc-before
             :butlast butlast
             :concat concat
+            :contains? &list:contains?
             :count &list:count
             :drop drop
             :each each
@@ -1315,3 +1319,9 @@
               if (list? x)
                 &list:empty? x
                 .empty? x
+
+        |contains? $ quote
+          defn contains? (x k)
+            if (nil? x) false
+              if (list? x) (&list:contains? x k)
+                .contains? x k

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -465,12 +465,9 @@
 
         |empty $ quote
           defn empty (x)
-            if (list? x) ([])
-              if (map? x) (&{})
-                if (set? x) (#{})
-                  if (string? x) |
-                    if (nil? x) nil
-                      raise $ &str-concat "|empty does not work on this type: " (&str x)
+            if (nil? x) nil
+              if (list? x) ([])
+                .empty x
 
         |pairs-map $ quote
           defn pairs-map (xs)
@@ -1178,6 +1175,7 @@
         |&core-number-class $ quote
           defrecord! &core-number-class
             :ceil ceil
+            :empty $ defn &number:empty (x) 0
             :floor floor
             :format format-number
             :inc inc
@@ -1191,7 +1189,7 @@
           defrecord! &core-string-class
             :blank? blank?
             :count &str:count
-            :empty empty
+            :empty $ defn &str:empty (x) |
             :ends-with? ends-with?
             :get nth
             :parse-float parse-float
@@ -1212,7 +1210,7 @@
             :count &set:count
             :difference difference
             :exclude exclude
-            :empty empty
+            :empty $ defn &set:empty (x) (#{})
             :empty? &set:empty?
             :include include
             :includes? includes?
@@ -1226,7 +1224,7 @@
             :contains? contains?
             :count &map:count
             :dissoc dissoc
-            :empty empty
+            :empty $ defn &map:empty (x) (&{})
             :empty? &map:empty?
             :get &get
             :get-in get-in
@@ -1262,7 +1260,7 @@
             :count &list:count
             :drop drop
             :each each
-            :empty empty
+            :empty $ defn &list:empty (x) ([])
             :empty? &list:empty?
             :filter filter
             :filter-not filter-not

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1204,6 +1204,7 @@
             :trim trim
             :empty? &str:empty?
             :contains? &str:contains?
+            :includes? &str:includes?
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1214,11 +1215,10 @@
             :empty $ defn &set:empty (x) (#{})
             :empty? &set:empty?
             :include include
-            :includes? includes?
+            :includes? &set:includes?
             :intersection intersection
             :to-list set->list
             :union union
-            :includes? includes?
 
         |&core-map-class $ quote
           defrecord! &core-map-class
@@ -1230,7 +1230,7 @@
             :empty? &map:empty?
             :get &get
             :get-in get-in
-            :includes? includes?
+            :includes? &map:includes?
             :keys keys
             :keys-non-nil keys-non-nil
             :map-kv map-kv
@@ -1261,6 +1261,7 @@
             :butlast butlast
             :concat concat
             :contains? &list:contains?
+            :includes? &list:includes?
             :count &list:count
             :drop drop
             :each each
@@ -1325,3 +1326,9 @@
             if (nil? x) false
               if (list? x) (&list:contains? x k)
                 .contains? x k
+
+        |includes? $ quote
+          defn includes? (x k)
+            if (nil? x) false
+              if (list? x) (&list:includes? x k)
+                .includes? x k

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -183,7 +183,7 @@
                       assert "|expected pair returned when mapping hashmap"
                         and (list? result) (&= 2 (&list:count result))
                       let[] (k2 v2) result
-                        assoc acc k2 v2
+                        &map:assoc acc k2 v2
               true
                 &let nil
                   echo "|value:" xs
@@ -464,7 +464,7 @@
             assert "|&map:add-entry expected value in a pair" $ and (list? pair)
               &= 2 (count pair)
             let[] (k v) pair
-              assoc xs k v
+              &map:assoc xs k v
 
         |empty $ quote
           defn empty (x)
@@ -480,7 +480,7 @@
                   if (list? pair)
                     &= 2 (&list:count pair)
                     , false
-                assoc acc (&list:first pair) (last pair)
+                &map:assoc acc (&list:first pair) (last pair)
 
         |some? $ quote
           defn some? (x) $ not $ nil? x
@@ -510,7 +510,7 @@
                   if (&list:empty? xs) true (&list:empty? ys)
                   , acc
                   recur
-                    assoc acc (&list:first xs) (&list:first ys)
+                    &map:assoc acc (&list:first xs) (&list:first ys)
                     rest xs
                     rest ys
 
@@ -598,7 +598,7 @@
                     recur
                       if (contains? acc key)
                         update acc key $ \ append % x0
-                        assoc acc key $ [] x0
+                        &map:assoc acc key $ [] x0
                       rest xs
 
         |keys $ quote
@@ -634,7 +634,7 @@
                     recur
                       if (contains? acc (&list:first xs))
                         update acc (&list:first xs) (\ &+ % 1)
-                        assoc acc (&list:first xs) 1
+                        &map:assoc acc (&list:first xs) 1
                       rest xs
 
         |section-by $ quote
@@ -917,7 +917,7 @@
                   assert "|expected pair returned when mapping hashmap"
                     and (list? result) (&= 2 (&list:count result))
                   let[] (k2 v2) result
-                    assoc acc k2 v2
+                    &map:assoc acc k2 v2
 
         |either $ quote
           defmacro either (& body)
@@ -1114,13 +1114,13 @@
           defn select-keys (m xs)
             assert "|expectd map for selecting" $ map? m
             foldl xs (&{}) $ fn (acc k)
-              assoc acc k (&map:get m k)
+              &map:assoc acc k (&map:get m k)
 
         |unselect-keys $ quote
           defn unselect-keys (m xs)
             assert "|expectd map for unselecting" $ map? m
             foldl xs m $ fn (acc k)
-              dissoc acc k
+              &map:dissoc acc k
 
         |conj $ quote
           defn conj (xs a)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -495,7 +495,7 @@
                       if (number? k)
                         recur (get x k) (rest path)
                         , false
-                      raise $ &str-concat "|Unknown structure for some-in? detection" x
+                      raise $ &str-concat "|Unknown structure for some-in? detection: " x
 
 
         |zipmap $ quote
@@ -566,11 +566,11 @@
             cond
               (list? x)
                 if (has-index? x k)
-                  assoc x k $ f (nth x k)
+                  assoc x k $ f (&list:nth x k)
                   , x
               (tuple? x)
                 if (or (&= k 1) (&= k 2))
-                  assoc x k $ f (nth x k)
+                  assoc x k $ f (&tuple:nth x k)
                   raise $ &str-concat "|tuple only has 0,1 fields, unknown field: " k
               (map? x)
                 if (contains? x k)
@@ -1191,7 +1191,7 @@
             :count &str:count
             :empty $ defn &str:empty (x) |
             :ends-with? ends-with?
-            :get nth
+            :get &str:nth
             :parse-float parse-float
             :parse-json parse-json
             :replace replace
@@ -1205,6 +1205,7 @@
             :empty? &str:empty?
             :contains? &str:contains?
             :includes? &str:includes?
+            :nth &str:nth
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1249,6 +1250,7 @@
             :turn-map turn-map
             :count &record:count
             :contains? &record:contains?
+            :nth &record:nth
 
         |&core-list-class $ quote
           defrecord! &core-list-class
@@ -1272,7 +1274,7 @@
             :find-index find-index
             :foldl foldl
             :frequencies frequencies
-            :get nth
+            :get &list:nth
             :get-in get-in
             :group-by group-by
             :has-index? has-index?
@@ -1283,7 +1285,7 @@
             :map-indexed map-indexed
             :max max
             :min min
-            :nth nth
+            :nth &list:nth
             :pairs-map pairs-map
             :prepend prepend
             :reduce reduce
@@ -1332,3 +1334,9 @@
             if (nil? x) false
               if (list? x) (&list:includes? x k)
                 .includes? x k
+
+        |nth $ quote
+          defn nth (x i)
+            if (tuple? x) (&tuple:nth x i)
+              if (list? x) (&list:nth x i)
+                .nth x i

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -571,6 +571,10 @@
                 if (has-index? x k)
                   assoc x k $ f (nth x k)
                   , x
+              (tuple? x)
+                if (or (&= k 1) (&= k 2))
+                  assoc x k $ f (nth x k)
+                  raise $ &str-concat "|tuple only has 0,1 fields, unknown field: " k
               (map? x)
                 if (contains? x k)
                   assoc x k $ f (&get x k)
@@ -1159,7 +1163,7 @@
         |negate $ quote
           defn negate (x)
             &- 0 x
-        
+
         |&number:rand-shift $ quote
           defn &number:rand-shift (x y)
             &+
@@ -1297,7 +1301,7 @@
             identity &core-list-class
             identity &core-map-class
             identity &core-record-class
-        
+
         |count $ quote
           defn count (x)
             if (nil? x) 0

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -33,11 +33,11 @@
 
         |when $ quote
           defmacro when (condition & body)
-            quote-replace $ if ~condition (&let nil ~@body)
+            quasiquote $ if ~condition (&let nil ~@body)
 
         |when-not $ quote
           defmacro when-not (condition & body)
-            quote-replace $ if (not ~condition) (&let nil ~@body)
+            quasiquote $ if (not ~condition) (&let nil ~@body)
 
         |+ $ quote
           defn + (x & ys) $ reduce ys x &+
@@ -201,8 +201,8 @@
         |str $ quote
           defmacro str (x0 & xs)
             if (&list:empty? xs)
-              quote-replace $ &str ~x0
-              quote-replace $ &str-concat ~x0 $ str ~@xs
+              quasiquote $ &str ~x0
+              quasiquote $ &str-concat ~x0 $ str ~@xs
 
         |include $ quote
           defn include (base & xs)
@@ -253,7 +253,7 @@
         |-> $ quote
           defmacro -> (base & xs)
             if (&list:empty? xs)
-              quote-replace ~base
+              quasiquote ~base
               &let
                 x0 (&list:first xs)
                 if (list? x0)
@@ -265,7 +265,7 @@
         |->> $ quote
           defmacro ->> (base & xs)
             if (&list:empty? xs)
-              quote-replace ~base
+              quasiquote ~base
               &let
                 x0 (&list:first xs)
                 if (list? x0)
@@ -282,7 +282,7 @@
                     map
                       butlast xs
                       fn (x) ([] '% x)
-                quote-replace
+                quasiquote
                   let ~pairs ~tail
 
         |cond $ quote
@@ -293,10 +293,10 @@
               expr $ &list:nth pair 0
               &let
                 branch $ &list:nth pair 1
-                quote-replace
+                quasiquote
                   if ~expr ~branch
                     ~ $ if (&list:empty? else) nil
-                      quote-replace
+                      quasiquote
                         cond
                           ~ $ &list:nth else 0
                           ~@ $ &list:rest else
@@ -335,17 +335,17 @@
             let
                 x $ &list:first pattern
                 branch $ last pattern
-              quote-replace
+              quasiquote
                 if (&= ~item ~x) ~branch
                   ~ $ if (&list:empty? others) default
-                    quote-replace
+                    quasiquote
                       &case ~item ~default ~@others
 
         |case $ quote
           defmacro case (item & patterns)
             &let
               v (gensym |v)
-              quote-replace
+              quasiquote
                 &let
                   ~v ~item
                   &case ~v nil ~@patterns
@@ -356,7 +356,7 @@
               raise "|Expected patterns for case-default, got empty"
             &let
               v (gensym |v)
-              quote-replace
+              quasiquote
                 &let (~v ~item)
                   &case ~v ~default ~@patterns
 
@@ -533,7 +533,7 @@
 
         |\ $ quote
           defmacro \ (& xs)
-            quote-replace $ fn (? % %2) ~xs
+            quasiquote $ fn (? % %2) ~xs
 
         |\. $ quote
           defmacro \. (args-alias & xs)
@@ -546,12 +546,12 @@
                 apply-args (inner-body args)
                   fn (body ys)
                     if (&list:empty? ys)
-                      quote-replace ~body
+                      quasiquote ~body
                       &let
                         a0 (last ys)
                         &let
                           code
-                            [] (quote-replace defn) (turn-symbol (&str-concat |f_ (turn-string a0))) ([] a0) body
+                            [] (quasiquote defn) (turn-symbol (&str-concat |f_ (turn-string a0))) ([] a0) body
                           recur code (butlast ys)
 
         |has-index? $ quote
@@ -655,30 +655,30 @@
           defmacro [][] (& xs)
             &let
               items $ map xs
-                fn (ys) $ quote-replace $ [] ~@ys
-              quote-replace $ [] ~@items
+                fn (ys) $ quasiquote $ [] ~@ys
+              quasiquote $ [] ~@items
 
         |{} $ quote
           defmacro {} (& xs)
             &let
               ys $ concat & xs
-              quote-replace $ &{} ~@ys
+              quasiquote $ &{} ~@ys
 
         |js-object $ quote
           defmacro js-object (& xs)
             &let
               ys $ concat & xs
-              quote-replace $ &js-object ~@ys
+              quasiquote $ &js-object ~@ys
 
         |%{} $ quote
           defmacro %{} (R & xs)
             &let
               args $ concat & xs
-              quote-replace $ &%{} ~R ~@args
+              quasiquote $ &%{} ~R ~@args
 
         |fn $ quote
           defmacro fn (args & body)
-            quote-replace $ defn f% ~args ~@body
+            quasiquote $ defn f% ~args ~@body
 
         |assert= $ quote
           defmacro assert= (a b)
@@ -686,7 +686,7 @@
               va $ gensym |va
               &let
                 vb $ gensym |vb
-                quote-replace
+                quasiquote
                   &let
                     ~va ~a
                     &let
@@ -704,7 +704,7 @@
           defmacro assert-detect (f code)
             &let
               v $ gensym |v
-              quote-replace
+              quasiquote
                 &let
                   ~v ~code
                   if (~f ~v) nil
@@ -716,7 +716,7 @@
 
         |swap! $ quote
           defmacro swap! (a f & args)
-            quote-replace
+            quasiquote
               reset! ~a
                 ~f (deref ~a) ~@args
 
@@ -782,7 +782,7 @@
                 args $ map pairs &list:first
                 values $ map pairs last
               assert "|loop requires symbols in pairs" (every? args symbol?)
-              quote-replace
+              quasiquote
                 apply
                   defn generated-loop ~args ~@body
                   [] ~@values
@@ -791,13 +791,13 @@
           defmacro let (pairs & body)
             assert "|expects pairs in list for let" (list? pairs)
             if (&= 1 (&list:count pairs))
-              quote-replace
+              quasiquote
                 &let
                   ~ $ &list:nth pairs 0
                   ~@ body
               if (&list:empty? pairs)
-                quote-replace $ &let nil ~@body
-                quote-replace
+                quasiquote $ &let nil ~@body
+                quasiquote
                   &let
                     ~ $ &list:nth pairs 0
                     let
@@ -808,15 +808,15 @@
           defmacro let-sugar (pairs & body)
             assert "|expects pairs in list for let" (list? pairs)
             if (&list:empty? pairs)
-              quote-replace $ &let nil ~@body
+              quasiquote $ &let nil ~@body
               &let
                 pair $ &list:first pairs
                 assert "|expected pair length of 2" (&= 2 (&list:count pair))
                 if (&= 1 (&list:count pairs))
-                  quote-replace
+                  quasiquote
                     let-destruct ~@pair
                       ~@ body
-                  quote-replace
+                  quasiquote
                     let-destruct ~@pair
                       let-sugar
                         ~ $ &list:rest pairs
@@ -825,14 +825,14 @@
         |let-destruct $ quote
           defmacro let-destruct (pattern v & body)
             if (symbol? pattern)
-              quote-replace
+              quasiquote
                 &let (~pattern ~v) ~@body
               if (list? pattern)
                 if (&= '[] (&list:first pattern))
-                  quote-replace
+                  quasiquote
                     let[] (~ (&list:rest pattern)) ~v ~@body
                   if (&= '{} (&list:first pattern))
-                    quote-replace
+                    quasiquote
                       let{} (~ (&list:rest pattern)) ~v ~@body
                     &let nil
                       echo pattern
@@ -844,14 +844,14 @@
             &let
               xs $ filter body
                 fn (x) (/= x ',)
-              quote-replace $ [] ~@xs
+              quasiquote $ [] ~@xs
 
         |assert $ quote
           defmacro assert (message xs)
             if
               if (string? xs) (not (string? message)) false
-              quote-replace $ assert ~xs ~message
-              quote-replace
+              quasiquote $ assert ~xs ~message
+              quasiquote
                 &let nil
                   if (not (string? ~message))
                     raise "|expects 1st argument to be string"
@@ -929,9 +929,9 @@
         |and $ quote
           defmacro and (item & xs)
             if (&list:empty? xs)
-              quote-replace
+              quasiquote
                 if ~item ~item false
-              quote-replace
+              quasiquote
                 if ~item
                   and
                     ~ $ &list:first xs
@@ -941,7 +941,7 @@
         |or $ quote
           defmacro or (item & xs)
             if (&list:empty? xs) item
-              quote-replace
+              quasiquote
                 if (nil? ~item)
                   or
                     ~ $ &list:first xs
@@ -956,7 +956,7 @@
           defmacro with-log (x)
             &let
               v $ gensym |v
-              quote-replace
+              quasiquote
                 &let
                   ~v ~x
                   echo (format-to-lisp (quote ~x)) |=> ~v
@@ -966,7 +966,7 @@
           defmacro with-js-log (x)
             &let
               v $ gensym |v
-              quote-replace
+              quasiquote
                 &let
                   ~v ~x
                   js/console.log (format-to-lisp (quote ~x)) |=> ~v
@@ -977,7 +977,7 @@
             &let
               xs $ filter body
                 fn (x) (not= x ',)
-              quote-replace
+              quasiquote
                 pairs-map $ section-by ([] ~@xs) 2
 
         |&doseq $ quote
@@ -987,7 +987,7 @@
             let
                 name $ &list:first pair
                 xs0 $ last pair
-              quote-replace
+              quasiquote
                 foldl ~xs0 nil $ defn doseq-fn% (_acc ~name) ~@body
 
         |with-cpu-time $ quote
@@ -995,7 +995,7 @@
             let
                 started $ gensym |started
                 v $ gensym |v
-              quote-replace
+              quasiquote
                 let
                     ~started (cpu-time)
                     ~v ~x
@@ -1011,7 +1011,7 @@
             let
                 v $ gensym |v
                 args-value $ gensym |args-value
-              quote-replace
+              quasiquote
                 let
                     ~args-value $ [] ~@xs
                     ~v $ ~f & ~args-value
@@ -1024,7 +1024,7 @@
 
         |defn-with-log $ quote
           defmacro defn-with-log (f-name args & body)
-            quote-replace
+            quasiquote
               defn ~f-name ~args
                 &let
                   ~f-name $ defn ~f-name ~args ~@body
@@ -1044,7 +1044,7 @@
               if (list? items) (every? items symbol?) false
             let
                 var-result $ gensym |result
-              quote-replace
+              quasiquote
                 &let
                   ~var-result ~base
                   assert (str "|expected map for destructing: " ~var-result) (map? ~var-result)
@@ -1073,12 +1073,12 @@
                         if (&= (&list:first xs) '&)
                           &let nil
                             assert "|expected list spreading" (&= 2 (&list:count xs))
-                            conj acc $ [] (&list:nth xs 1) (quote-replace (slice ~v ~idx))
+                            conj acc $ [] (&list:nth xs 1) (quasiquote (slice ~v ~idx))
                           recur
-                            conj acc $ [] (&list:first xs) (quote-replace (&list:nth ~v ~idx))
+                            conj acc $ [] (&list:first xs) (quasiquote (&list:nth ~v ~idx))
                             rest xs
                             inc idx
-              quote-replace
+              quasiquote
                 &let
                   ~v ~data
                   let
@@ -1087,7 +1087,7 @@
 
         |defrecord $ quote
           defmacro defrecord (name & xs)
-            quote-replace
+            quasiquote
               new-record (quote ~name) ~@xs
 
         |defrecord! $ quote

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1206,6 +1206,7 @@
             :contains? &str:contains?
             :includes? &str:includes?
             :nth &str:nth
+            :first &str:first
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1220,6 +1221,7 @@
             :intersection intersection
             :to-list set->list
             :union union
+            :first &set:first
 
         |&core-map-class $ quote
           defrecord! &core-map-class
@@ -1241,6 +1243,7 @@
             :to-pairs to-pairs
             :unselect-keys unselect-keys
             :vals vals
+            :first &map:first
 
         |&core-record-class $ quote
           defrecord! &core-record-class
@@ -1297,6 +1300,7 @@
             :sort-by &list-sort-by
             :take take
             :zipmap zipmap
+            :first &list:first
 
         |&init-builtin-classes! $ quote
           defn &init-builtin-classes! ()
@@ -1340,3 +1344,9 @@
             if (tuple? x) (&tuple:nth x i)
               if (list? x) (&list:nth x i)
                 .nth x i
+
+        |first $ quote
+          defn nth (x)
+            if (tuple? x) (&tuple:nth x 0)
+              if (list? x) (&list:nth x 0)
+                .first x

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1207,6 +1207,7 @@
             :includes? &str:includes?
             :nth &str:nth
             :first &str:first
+            :rest &str:rest
 
         |&core-set-class $ quote
           defrecord! &core-set-class
@@ -1222,6 +1223,7 @@
             :to-list set->list
             :union union
             :first &set:first
+            :rest &set:rest
 
         |&core-map-class $ quote
           defrecord! &core-map-class
@@ -1244,6 +1246,7 @@
             :unselect-keys unselect-keys
             :vals vals
             :first &map:first
+            :rest &map:rest
 
         |&core-record-class $ quote
           defrecord! &core-record-class
@@ -1301,6 +1304,7 @@
             :take take
             :zipmap zipmap
             :first &list:first
+            :rest &list:rest
 
         |&init-builtin-classes! $ quote
           defn &init-builtin-classes! ()
@@ -1347,6 +1351,13 @@
 
         |first $ quote
           defn nth (x)
-            if (tuple? x) (&tuple:nth x 0)
-              if (list? x) (&list:nth x 0)
-                .first x
+            if (nil? x) nil
+              if (tuple? x) (&tuple:nth x 0)
+                if (list? x) (&list:nth x 0)
+                  .first x
+         
+        |rest $ quote
+          defn rest (x)
+            if (nil? x) nil
+              if (list? x) (&list:rest x)
+                .rest x

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -324,7 +324,7 @@ fn gen_call_code(
         },
 
         "defmacro" => Ok(format!("/* Unexpected macro {} */", xs)),
-        "quote-replace" | "quasiquote" => Ok(format!("(/* Unexpected quasiquote {} */ null)", xs.lisp_str())),
+        "quasiquote" | "quote-replace" => Ok(format!("(/* Unexpected quasiquote {} */ null)", xs.lisp_str())),
 
         "raise" => {
           // not core syntax, but treat as macro for better debugging experience

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -129,6 +129,7 @@ fn is_preferred_js_proc(name: &str) -> bool {
       | "bool?"
       | "ref?"
       | "record?"
+      | "tuple?"
       | "starts-with?"
       | "ends-with?"
   )

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -251,7 +251,7 @@ fn process_list_call(
       }
     }
     (Calcit::Syntax(name, name_ns), _) => match name.as_str() {
-      "quote-replace" | "quasiquote" => Ok((
+      "quasiquote" | "quote-replace" => Ok((
         preprocess_quasiquote(&name, &name_ns, args, scope_defs, file_ns, program_code)?,
         None,
       )),

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -209,7 +209,11 @@ fn process_list_call(
     (Calcit::Keyword(..), _) => {
       if args.len() == 1 {
         let code = Calcit::List(im::vector![
-          Calcit::Proc(String::from("&get")),
+          Calcit::Symbol(
+            String::from("get"),
+            String::from(primes::CORE_NS),
+            Some(ResolvedDef(String::from(primes::CORE_NS), String::from("get"), None))
+          ),
           args[0].clone(),
           head.clone()
         ]);


### PR DESCRIPTION
For performance and consistency.

Also `nth` no longer support native JavaScript arrays. use `aget` instead.

