### PR TITLE
Breaking refactor to unify APIs; starting 0.4.0-a1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a1"
+version = "0.4.0-a2"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a4"
+version = "0.4.0-a5"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a3"
+version = "0.4.0-a4"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.3.39"
+version = "0.4.0-a1"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a2"
+version = "0.4.0-a3"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a1"
+version = "0.4.0-a2"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.3.39"
+version = "0.4.0-a1"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a4"
+version = "0.4.0-a5"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a3"
+version = "0.4.0-a4"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a2"
+version = "0.4.0-a3"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/calcit/snapshots/fibo.cirru
+++ b/calcit/snapshots/fibo.cirru
@@ -31,7 +31,7 @@
             if (&> n limit) acc $ if
               every?
                 fn (m)
-                  &> (rem n m) 0
+                  &> (.rem n m) 0
                 , acc
               recur (conj acc n) (inc n) (, limit)
               recur acc (inc n) limit

--- a/calcit/snapshots/test-list.cirru
+++ b/calcit/snapshots/test-list.cirru
@@ -33,18 +33,21 @@
               assert= (slice (range 10) 0 10) (range 10)
               assert= (slice (range 10) 5 7) ([] 5 6)
               assert=
-                concat (range 10) (range 4)
+                &list:concat (range 10) (range 4)
                 [] 0 1 2 3 4 5 6 7 8 9 0 1 2 3
               assert=
-                concat $ [] 1 2 3
+                &list:concat $ [] 1 2 3
                 [] 1 2 3
+              assert "|&list:concat lists" $ =
+                &list:concat ([] 1 2) ([] 4 5) ([] 7 8)
+                [] 1 2 4 5 7 8
               assert "|concat lists" $ =
                 concat ([] 1 2) ([] 4 5) ([] 7 8)
                 [] 1 2 4 5 7 8
               
               assert=
                 [] 3 4 5 2 3
-                concat
+                &list:concat
                   slice ([] 1 2 3 4 5 6) 2 5
                   slice ([] 1 2 3 4 5 6) 1 3
               assert=
@@ -56,7 +59,7 @@
               assert= (take (range 10) 4) $ [] 0 1 2 3
               assert= (drop (range 10) 4) ([] 4 5 6 7 8 9)
               assert |reverse $ =
-                reverse $ [] |a |b |c |d |e
+                .reverse $ [] |a |b |c |d |e
                 [] |e |d |c |b |a
 
               assert=
@@ -147,7 +150,7 @@
             assert=
               group-by
                 range 10
-                \ rem % 3
+                \ .rem % 3
               {}
                 0 $ [] 0 3 6 9
                 1 $ [] 1 4 7
@@ -286,7 +289,7 @@
             log-title "|Testing let[]"
 
             inside-eval:
-              echo $ macroexpand $ quote
+              echo $ format-to-lisp $ macroexpand $ quote
                 let[] (a b c & d) ([] 1 2 3 4 5)
                   echo a
                   echo b

--- a/calcit/snapshots/test-macro.cirru
+++ b/calcit/snapshots/test-macro.cirru
@@ -283,7 +283,7 @@
                     echo |[cpu-time]
                       format-to-lisp (quote $ + 1 2)
                       , |=>
-                      format-number (&- (cpu-time) started__1) 3
+                      .format (&- (cpu-time) started__1) 3
                       , |ms
                     , v__2
 

--- a/calcit/snapshots/test-math.cirru
+++ b/calcit/snapshots/test-math.cirru
@@ -57,8 +57,10 @@
             assert= 2 $ ceil 1.1
             assert= 1 $ round 1.1
             assert= 2 $ round 1.8
+            assert= 2 $ .round 1.8
+            assert= 0.8 $ .fract 1.8
             assert= 81 $ pow 3 4
-            assert= 1 $ rem 33 4
+            assert= 1 $ &number:rem 33 4
             assert= 9 $ sqrt 81
             echo |PI &PI
             echo |E &E
@@ -81,8 +83,8 @@
           fn ()
             log-title "|Testing integer"
 
-            assert= true (integer? 1)
-            assert= false (integer? 1.1)
+            assert= true (round? 1)
+            assert= false (round? 1.1)
 
         |test-methods $ quote
           fn ()

--- a/calcit/snapshots/test-record.cirru
+++ b/calcit/snapshots/test-record.cirru
@@ -37,12 +37,12 @@
 
               assert= :record $ type-of p1
               assert=
-                turn-map p1
+                .to-map p1
                 {} (:name |Chen) (:age 20) (:position :mainland)
 
               assert= 21
                 get
-                  make-record Person $ {}
+                  .from-map Person $ {}
                     :name |Chen
                     :age 21
                     :position :mainland
@@ -52,9 +52,9 @@
                 keys p2
                 [] :age :name :position
 
-              assert-detect identity $ relevant-record? p1 p1
-              assert-detect identity $ relevant-record? p1 p2
-              assert-detect not $ relevant-record? p1 c1
+              assert-detect identity $ &record:matches? p1 p1
+              assert-detect identity $ &record:matches? p1 p2
+              assert-detect not $ &record:matches? p1 c1
 
               &let
                 p4 $ assoc p1 :age 30

--- a/calcit/snapshots/test-record.cirru
+++ b/calcit/snapshots/test-record.cirru
@@ -54,7 +54,9 @@
 
               assert-detect identity $ &record:matches? p1 p1
               assert-detect identity $ &record:matches? p1 p2
+              assert-detect identity $ .matches? p1 p2
               assert-detect not $ &record:matches? p1 c1
+              assert-detect not $ .matches? p1 c1
 
               &let
                 p4 $ assoc p1 :age 30

--- a/calcit/snapshots/test-recursion.cirru
+++ b/calcit/snapshots/test-recursion.cirru
@@ -19,7 +19,7 @@
               if (&= x 1) (, 0)
                 if (&= x 2) (, 1)
                   let
-                      extra $ rem x 3
+                      extra $ .rem x 3
                     if (&= extra 0)
                       let
                           unit $ &/ x 3

--- a/calcit/snapshots/test-string.cirru
+++ b/calcit/snapshots/test-string.cirru
@@ -10,8 +10,8 @@
 
         |test-str $ quote
           defn test-str ()
-            assert= (&str-concat |a |b) |ab
-            assert= (&str-concat 1 2) |12
+            assert= (&str:concat |a |b) |ab
+            assert= (&str:concat 1 2) |12
             assert= (str |a |b |c) |abc
             assert= (str 1 2 3) |123
             assert= (type-of (&str 1)) :string
@@ -29,13 +29,13 @@
               [] |a |中 |b |文 |c
             assert= 4
               count |good
-            assert= |56789 $ substr |0123456789 5
-            assert= |567 $ substr |0123456789 5 8
-            assert= | $ substr |0123456789 10
-            assert= | $ substr |0123456789 9 1
-            assert= -1 $ compare-string |a |b
-            assert= 1 $ compare-string |b |a
-            assert= 0 $ compare-string |a |a
+            assert= |56789 $ .slice |0123456789 5
+            assert= |567 $ .slice |0123456789 5 8
+            assert= | $ .slice |0123456789 10
+            assert= | $ .slice |0123456789 9 1
+            assert= -1 $ &str:compare |a |b
+            assert= 1 $ &str:compare |b |a
+            assert= 0 $ &str:compare |a |a
 
             assert-detect identity $ < |a |b
             assert-detect identity $ < |aa |ab
@@ -91,10 +91,10 @@
           fn ()
             log-title "|Testing format"
 
-            assert= |1.2346 $ format-number 1.23456789 4
-            assert= |1.235 $ format-number 1.23456789 3
-            assert= |1.23 $ format-number 1.23456789 2
-            assert= |1.2 $ format-number 1.23456789 1
+            assert= |1.2346 $ .format 1.23456789 4
+            assert= |1.235 $ .format 1.23456789 3
+            assert= |1.23 $ .format 1.23456789 2
+            assert= |1.2 $ .format 1.23456789 1
 
             inside-eval:
 
@@ -114,7 +114,7 @@
                 pr-str $ %{} Person (:name |Chen) (:age 23)
                 , "|(%{} Person (age 23) (name |Chen))"
               assert= edn-demo
-                trim $ write-cirru-edn $ %{} Person (:name |Chen) (:age 23)
+                trim $ format-cirru-edn $ %{} Person (:name |Chen) (:age 23)
 
               assert=
                 parse-cirru-edn edn-demo
@@ -123,24 +123,24 @@
               assert= 'a
                 parse-cirru-edn "|do 'a"
               assert= "|[] 'a"
-                trim $ write-cirru-edn $ [] 'a
+                trim $ format-cirru-edn $ [] 'a
 
               assert= "|do nil"
-                trim $ write-cirru-edn nil
+                trim $ format-cirru-edn nil
 
               assert= "|do 's"
-                trim $ write-cirru-edn 's
+                trim $ format-cirru-edn 's
 
-              assert= (escape "|\n") "|\"\\n\""
-              assert= (escape "|\t") "|\"\\t\""
-              assert= (escape "|a") "|\"a\""
+              assert= (.escape "|\n") "|\"\\n\""
+              assert= (.escape "|\t") "|\"\\t\""
+              assert= (.escape "|a") "|\"a\""
 
         |test-char $ quote
           fn ()
             log-title "|Test char"
 
-            assert= 97 $ get-char-code |a
-            assert= 27721 $ get-char-code |汉
+            assert= 97 $ .get-char-code |a
+            assert= 27721 $ .get-char-code |汉
 
             assert= |a $ nth |abc 0
             assert= |b $ nth |abc 1

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -119,10 +119,10 @@
                 format-time 1605024100
               assert= "|2020-11-10T16:01:40.123Z"
                 format-time 1605024100.1234
-              echo $ format-time (now!) "|yyyy-MM-dd HH:mm:ss ffffff"
+              echo $ format-time (get-time!) "|yyyy-MM-dd HH:mm:ss ffffff"
 
             inside-eval:
-              echo |time: $ format-time (now!) "|%Y-%m-%d %H:%M:%S %z"
+              echo |time: $ format-time (get-time!) "|%Y-%m-%d %H:%M:%S %z"
               assert= 1417176009000
                 parse-time "|2014-11-28 21:00:09 +09:00" "|%Y-%m-%d %H:%M:%S %z"
               assert= "|2014-11-28 12:00:09 +0000"
@@ -137,7 +137,7 @@
         |test-display-stack $ quote
           fn ()
             log-title "|Testing display stack"
-            display-stack "|show stack here"
+            &display-stack "|show stack here"
 
         |test-cirru-parser $ quote
           fn ()
@@ -158,9 +158,9 @@
                 :b $ [] 3 |4 nil
 
             assert= "|[] |a |b $ [] |c |d"
-              trim $ write-cirru-edn $ [] |a |b $ [] |c |d
+              trim $ format-cirru-edn $ [] |a |b $ [] |c |d
             assert= "|a b $ c d"
-              trim $ write-cirru $ [] $ [] |a |b $ [] |c |d
+              trim $ format-cirru $ [] $ [] |a |b $ [] |c |d
 
         |test-fn $ quote
           fn ()

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -204,6 +204,12 @@
                     echo "|Caught error:" error
                     , :false
 
+            fn ()
+              try
+                raise |false
+                fn (error)
+                  str :a
+
             echo "|Finished testing try"
 
         |test-fn-eq $ quote
@@ -266,7 +272,7 @@
           defn main! ()
             inside-js:
               load-console-formatter!
-          
+
             log-title "|Testing keyword function"
             test-keyword
 

--- a/calcit/snapshots/test.cirru
+++ b/calcit/snapshots/test.cirru
@@ -204,11 +204,12 @@
                     echo "|Caught error:" error
                     , :false
 
-            fn ()
-              try
-                raise |false
-                fn (error)
-                  str :a
+            assert= |:a
+              apply-args () $ fn ()
+                try
+                  raise |false
+                  fn (error)
+                    str :a
 
             echo "|Finished testing try"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a3",
+  "version": "0.4.0-a4",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a4",
+  "version": "0.4.0-a5",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a1",
+  "version": "0.4.0-a2",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a2",
+  "version": "0.4.0-a3",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.3.39",
+  "version": "0.4.0-a1",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,3 +1,2 @@
-
-import * as appMain from "./app.main.js"
-appMain.main_BANG_()
+import * as appMain from "./app.main.js";
+appMain.main_$x_();

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -26,32 +26,42 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&reset-gensym-index!"
       | "&get-calcit-running-mode"
       | "generate-id!"
-      | "display-stack"
-      | "parse-cirru"
-      | "write-cirru"
-      | "parse-cirru-edn"
-      | "write-cirru-edn"
       | "turn-symbol"
       | "turn-keyword"
-      | "::" // unstable
       | "&compare"
+      // tuples
+      | "::" // unstable
       | "&tuple:nth"
       | "&tuple:assoc"
       // effects
+      | "&display-stack"
       | "echo"
       | "println" // alias for echo
       | "echo-values"
       | "raise"
-      | "cpu-time"
-      | "quit"
+      | "quit!"
       | "get-env"
       | "&get-calcit-backend"
       | "read-file"
       | "write-file"
+      | "&ffi-message"
+      // external format
+      | "parse-cirru"
+      | "format-cirru"
+      | "parse-cirru-edn"
+      | "format-cirru-edn"
+      | "parse-json"
+      | "stringify-json"
+      // regex
+      | "re-matches"
+      | "re-find"
+      | "re-find-index"
+      | "re-find-all"
+      // time
+      | "cpu-time"
       | "format-time"
       | "parse-time"
-      | "now!"
-      | "&ffi-message"
+      | "get-time!"
       // logics
       | "&="
       | "&<"
@@ -64,40 +74,36 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&*"
       | "&/"
       | "round"
-      | "fractional" // TODO
       | "rand"
       | "rand-int"
       | "floor"
-      | "rem"
       | "sin"
       | "cos"
       | "pow"
       | "ceil"
       | "sqrt"
-      | "integer?"
+      | "round?"
+      | "&number:fract"
+      | "&number:rem"
+      | "&number:format"
       // strings
-      | "&str-concat"
+      | "&str:concat"
       | "trim"
       | "&str"
       | "turn-string"
       | "split"
-      | "format-number"
-      | "&str:replace"
       | "split-lines"
-      | "substr"
-      | "compare-string"
-      | "&str:find-index"
       | "starts-with?"
       | "ends-with?"
       | "get-char-code"
-      | "re-matches"
-      | "re-find"
-      | "parse-float"
       | "pr-str"
-      | "re-find-index"
-      | "re-find-all"
+      | "parse-float"
       | "blank?"
-      | "escape"
+      | "&str:compare"
+      | "&str:replace"
+      | "&str:slice"
+      | "&str:find-index"
+      | "&str:escape"
       | "&str:count"
       | "&str:empty?"
       | "&str:contains?"
@@ -108,17 +114,17 @@ pub fn is_proc_name(s: &str) -> bool {
       // lists
       | "[]"
       | "'" // used as an alias for `[]`, experimental
-      | "&list:count"
-      | "&list:empty?"
-      | "slice"
       | "append"
       | "prepend"
       | "butlast"
-      | "concat"
       | "range"
-      | "reverse"
-      | "assoc-before"
-      | "assoc-after"
+      | "&list:reverse"
+      | "&list:concat"
+      | "&list:count"
+      | "&list:empty?"
+      | "&list:slice"
+      | "&list:assoc-before"
+      | "&list:assoc-after"
       | "&list:contains?"
       | "&list:includes?"
       | "&list:nth"
@@ -128,11 +134,11 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&list:dissoc"
       // maps
       | "&{}"
-      | "&map:get"
-      | "&map:dissoc"
       | "&merge"
       | "to-pairs"
       | "&merge-non-nil"
+      | "&map:get"
+      | "&map:dissoc"
       | "&map:to-list"
       | "&map:count"
       | "&map:empty?"
@@ -147,17 +153,14 @@ pub fn is_proc_name(s: &str) -> bool {
       | "&exclude"
       | "&difference"
       | "&union"
-      | "&intersection"
-      | "set->list"
+      | "&set:intersection"
+      | "&set:to-list"
       | "&set:count"
       | "&set:empty?"
       | "&set:includes?"
       | "&set:first"
       | "&set:rest"
       | "&set:assoc"
-      // json
-      | "parse-json"
-      | "stringify-json"
       // refs
       | "deref"
       | "add-watch"
@@ -165,10 +168,10 @@ pub fn is_proc_name(s: &str) -> bool {
       // records
       | "new-record"
       | "&%{}"
-      | "make-record" // TODO switch to (into-record xs r) ?
-      | "get-record-name"
-      | "turn-map"
-      | "relevant-record?" // regexs
+      | "&record:matches?"
+      | "&record:from-map"
+      | "&record:get-name"
+      | "&record:to-map"
       | "&record:count"
       | "&record:contains?"
       | "&record:nth"
@@ -187,32 +190,42 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&reset-gensym-index!" => meta::reset_gensym_index(args),
     "&get-calcit-running-mode" => effects::calcit_running_mode(args),
     "generate-id!" => meta::generate_id(args),
-    "display-stack" => meta::display_stack(args),
-    "parse-cirru" => meta::parse_cirru(args),
-    "write-cirru" => meta::write_cirru(args),
-    "parse-cirru-edn" => meta::parse_cirru_edn(args),
-    "write-cirru-edn" => meta::write_cirru_edn(args),
     "turn-symbol" => meta::turn_symbol(args),
     "turn-keyword" => meta::turn_keyword(args),
-    "::" => meta::new_tuple(args), // unstable solution for the name
     "&compare" => meta::native_compare(args),
+    // tuple
+    "::" => meta::new_tuple(args), // unstable solution for the name
     "&tuple:nth" => meta::tuple_nth(args),
     "&tuple:assoc" => meta::assoc(args),
     // effects
+    "&display-stack" => meta::display_stack(args),
     "echo" => effects::echo(args),
     "println" => effects::echo(args), // alias
     "echo-values" => effects::echo_values(args),
     "raise" => effects::raise(args),
-    "cpu-time" => effects::cpu_time(args),
-    "quit" => effects::quit(args),
+    "quit!" => effects::quit(args),
     "get-env" => effects::get_env(args),
     "&get-calcit-backend" => effects::call_get_calcit_backend(args),
     "read-file" => effects::read_file(args),
     "write-file" => effects::write_file(args),
+    "&ffi-message" => effects::ffi_message(args),
+    // external data format
+    "parse-cirru" => meta::parse_cirru(args),
+    "format-cirru" => meta::write_cirru(args),
+    "parse-cirru-edn" => meta::parse_cirru_edn(args),
+    "format-cirru-edn" => meta::write_cirru_edn(args),
+    "parse-json" => json::parse_json(args),
+    "stringify-json" => json::stringify_json(args),
+    // time
+    "cpu-time" => effects::cpu_time(args),
     "parse-time" => effects::parse_time(args),
     "format-time" => effects::format_time(args),
-    "now!" => effects::now_bang(args),
-    "&ffi-message" => effects::ffi_message(args),
+    "get-time!" => effects::now_bang(args),
+    // regex
+    "re-matches" => regexes::re_matches(args),
+    "re-find" => regexes::re_find(args),
+    "re-find-index" => regexes::re_find_index(args),
+    "re-find-all" => regexes::re_find_all(args),
     // logics
     "&=" => logics::binary_equal(args),
     "&<" => logics::binary_less(args),
@@ -228,34 +241,34 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "rand" => math::rand(args),
     "rand-int" => math::rand_int(args),
     "floor" => math::floor(args),
-    "rem" => math::rem(args),
     "sin" => math::sin(args),
     "cos" => math::cos(args),
     "pow" => math::pow(args),
     "ceil" => math::ceil(args),
     "sqrt" => math::sqrt(args),
     "round" => math::round(args),
-    "fractional" => math::fractional(args),
-    "integer?" => math::integer_ques(args),
+    "round?" => math::round_ques(args),
+    "&number:rem" => math::rem(args),
+    "&number:fract" => math::fractional(args),
+    "&number:format" => strings::format_number(args),
     // strings
-    "&str-concat" => strings::binary_str_concat(args),
     "trim" => strings::trim(args),
     "&str" => strings::call_str(args),
     "turn-string" => strings::turn_string(args),
     "split" => strings::split(args),
-    "format-number" => strings::format_number(args),
-    "&str:replace" => strings::replace(args),
     "split-lines" => strings::split_lines(args),
-    "substr" => strings::substr(args),
-    "compare-string" => strings::compare_string(args),
-    "&str:find-index" => strings::find_index(args),
     "starts-with?" => strings::starts_with_ques(args),
     "ends-with?" => strings::ends_with_ques(args),
     "get-char-code" => strings::get_char_code(args),
     "parse-float" => strings::parse_float(args),
     "pr-str" => strings::pr_str(args),
     "blank?" => strings::blank_ques(args),
-    "escape" => strings::escape(args),
+    "&str:concat" => strings::binary_str_concat(args),
+    "&str:slice" => strings::str_slice(args),
+    "&str:compare" => strings::compare_string(args),
+    "&str:find-index" => strings::find_index(args),
+    "&str:replace" => strings::replace(args),
+    "&str:escape" => strings::escape(args),
     "&str:count" => strings::count(args),
     "&str:empty?" => strings::empty_ques(args),
     "&str:contains?" => strings::contains_ques(args),
@@ -263,23 +276,18 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&str:nth" => strings::nth(args),
     "&str:first" => strings::first(args),
     "&str:rest" => strings::rest(args),
-    // regex
-    "re-matches" => regexes::re_matches(args),
-    "re-find" => regexes::re_find(args),
-    "re-find-index" => regexes::re_find_index(args),
-    "re-find-all" => regexes::re_find_all(args),
     // lists
     "[]" => lists::new_list(args),
     "'" => lists::new_list(args), // alias
-    "slice" => lists::slice(args),
     "append" => lists::append(args),
     "prepend" => lists::prepend(args),
     "butlast" => lists::butlast(args),
-    "concat" => lists::concat(args),
+    "&list:concat" => lists::concat(args),
     "range" => lists::range(args),
-    "reverse" => lists::reverse(args),
-    "assoc-before" => lists::assoc_before(args),
-    "assoc-after" => lists::assoc_after(args),
+    "&list:reverse" => lists::reverse(args),
+    "&list:slice" => lists::slice(args),
+    "&list:assoc-before" => lists::assoc_before(args),
+    "&list:assoc-after" => lists::assoc_after(args),
     "&list:count" => lists::count(args),
     "&list:empty?" => lists::empty_ques(args),
     "&list:contains?" => lists::contains_ques(args),
@@ -310,16 +318,13 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     "&exclude" => sets::call_exclude(args),
     "&difference" => sets::call_difference(args),
     "&union" => sets::call_union(args),
-    "&intersection" => sets::call_intersection(args),
-    "set->list" => sets::set_to_list(args),
+    "&set:intersection" => sets::call_intersection(args),
+    "&set:to-list" => sets::set_to_list(args),
     "&set:count" => sets::count(args),
     "&set:empty?" => sets::empty_ques(args),
     "&set:includes?" => sets::includes_ques(args),
     "&set:first" => sets::first(args),
     "&set:rest" => sets::rest(args),
-    // json
-    "parse-json" => json::parse_json(args),
-    "stringify-json" => json::stringify_json(args),
     // refs
     "deref" => refs::deref(args),
     "add-watch" => refs::add_watch(args),
@@ -327,10 +332,10 @@ pub fn handle_proc(name: &str, args: &CalcitItems) -> Result<Calcit, String> {
     // records
     "new-record" => records::new_record(args),
     "&%{}" => records::call_record(args),
-    "make-record" => records::record_from_map(args), // TODO switch to (into-record xs r) ?
-    "get-record-name" => records::get_record_name(args),
-    "turn-map" => records::turn_map(args),
-    "relevant-record?" => records::relevant_record_ques(args),
+    "&record:from-map" => records::record_from_map(args),
+    "&record:get-name" => records::get_record_name(args),
+    "&record:to-map" => records::turn_map(args),
+    "&record:matches?" => records::matches(args),
     "&record:count" => records::count(args),
     "&record:contains?" => records::contains_ques(args),
     "&record:nth" => records::nth(args),
@@ -349,7 +354,6 @@ pub fn is_syntax_name(s: &str) -> bool {
       | "&let"
       | "quote"
       | "quasiquote"
-      | "quote-replace" // alias for quasiquote
       | "eval"
       | "macroexpand"
       | "macroexpand-1"
@@ -376,7 +380,6 @@ pub fn handle_syntax(
     "defmacro" => syntax::defmacro(nodes, scope, file_ns, program),
     "quote" => syntax::quote(nodes, scope, file_ns, program),
     "quasiquote" => syntax::quasiquote(nodes, scope, file_ns, program),
-    "quote-replace" => syntax::quasiquote(nodes, scope, file_ns, program), // alias
     "if" => syntax::syntax_if(nodes, scope, file_ns, program),
     "&let" => syntax::syntax_let(nodes, scope, file_ns, program),
     "foldl" => lists::foldl(nodes, scope, file_ns, program),

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -69,6 +69,7 @@ pub fn call_merge(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
+/// to set
 pub fn to_pairs(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     // get a random order from internals

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -38,11 +38,11 @@ pub fn binary_divide(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-pub fn integer_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+pub fn round_ques(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     Some(Calcit::Number(n)) => Ok(Calcit::Bool(is_integer(*n))),
-    Some(a) => Err(format!("integer? expected a number: {}", a)),
-    a => Err(format!("integer? expected 1 number: {:?}", a)),
+    Some(a) => Err(format!("round? expected a number: {}", a)),
+    a => Err(format!("round? expected 1 number: {:?}", a)),
   }
 }
 

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -146,7 +146,7 @@ pub fn write_cirru(xs: &CalcitItems) -> Result<Calcit, String> {
       let options = cirru_parser::CirruWriterOptions { use_inline: false };
       match cirru::calcit_data_to_cirru(a) {
         Ok(v) => Ok(Calcit::Str(cirru_parser::format(&v, options)?)),
-        Err(e) => Err(format!("write-cirru failed, {}", e)),
+        Err(e) => Err(format!("format-cirru failed, {}", e)),
       }
     }
     None => Err(String::from("parse-cirru expected 1 argument")),
@@ -167,7 +167,7 @@ pub fn parse_cirru_edn(xs: &CalcitItems) -> Result<Calcit, String> {
 pub fn write_cirru_edn(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     Some(a) => Ok(Calcit::Str(cirru_edn::format(&edn::calcit_to_edn(a), true)?)),
-    None => Err(String::from("write-cirru-edn expected 1 argument")),
+    None => Err(String::from("format-cirru-edn expected 1 argument")),
   }
 }
 

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -67,7 +67,6 @@ pub fn call_record(xs: &CalcitItems) -> Result<Calcit, String> {
   }
 }
 
-/// TODO the name is current `make-record`
 pub fn record_from_map(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Record(name, fields, _values)), Some(Calcit::Map(ys))) => {
@@ -99,16 +98,16 @@ pub fn record_from_map(xs: &CalcitItems) -> Result<Calcit, String> {
       pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
       Ok(Calcit::Record(name.clone(), fields.clone(), values))
     }
-    (Some(a), Some(b)) => Err(format!("make-record expected a record and a map, got {} {}", a, b)),
-    (_, _) => Err(format!("make-record expected 2 arguments, got {:?}", xs)),
+    (Some(a), Some(b)) => Err(format!("&record:from-map expected a record and a map, got {} {}", a, b)),
+    (_, _) => Err(format!("&record:from-map expected 2 arguments, got {:?}", xs)),
   }
 }
 
 pub fn get_record_name(xs: &CalcitItems) -> Result<Calcit, String> {
   match xs.get(0) {
     Some(Calcit::Record(name, ..)) => Ok(Calcit::Str(name.to_owned())),
-    Some(a) => Err(format!("get-record-name expected record, got: {}", a)),
-    None => Err(String::from("get-record-name expected record, got nothing")),
+    Some(a) => Err(format!("&record:get-name expected record, got: {}", a)),
+    None => Err(String::from("&record:get-name expected record, got nothing")),
   }
 }
 pub fn turn_map(xs: &CalcitItems) -> Result<Calcit, String> {
@@ -120,17 +119,17 @@ pub fn turn_map(xs: &CalcitItems) -> Result<Calcit, String> {
       }
       Ok(Calcit::Map(ys))
     }
-    Some(a) => Err(format!("turn-map expected a record, got {}", a)),
-    None => Err(String::from("turn-map expected 1 argument, got nothing")),
+    Some(a) => Err(format!("&record:to-map expected a record, got {}", a)),
+    None => Err(String::from("&record:to-map expected 1 argument, got nothing")),
   }
 }
-pub fn relevant_record_ques(xs: &CalcitItems) -> Result<Calcit, String> {
+pub fn matches(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Record(left, left_fields, ..)), Some(Calcit::Record(right, right_fields, ..))) => {
       Ok(Calcit::Bool(left == right && left_fields == right_fields))
     }
-    (Some(a), Some(b)) => Err(format!("relevant-record? expected 2 records, got {} {}", a, b)),
-    (_, _) => Err(format!("relevant-record? expected 2 arguments, got {:?}", xs)),
+    (Some(a), Some(b)) => Err(format!("&record:matches? expected 2 records, got {} {}", a, b)),
+    (_, _) => Err(format!("&record:matches? expected 2 arguments, got {:?}", xs)),
   }
 }
 

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -56,8 +56,8 @@ pub fn call_union(xs: &CalcitItems) -> Result<Calcit, String> {
 pub fn call_intersection(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => Ok(Calcit::Set(a.clone().intersection(b.clone()))),
-    (Some(a), Some(b)) => Err(format!("&intersection expected 2 sets: {} {}", a, b)),
-    (a, b) => Err(format!("&intersection expected 2 arguments: {:?} {:?}", a, b)),
+    (Some(a), Some(b)) => Err(format!("&set:intersection expected 2 sets: {} {}", a, b)),
+    (a, b) => Err(format!("&set:intersection expected 2 arguments: {:?} {:?}", a, b)),
   }
 }
 
@@ -71,8 +71,8 @@ pub fn set_to_list(xs: &CalcitItems) -> Result<Calcit, String> {
       }
       Ok(Calcit::List(ys))
     }
-    Some(a) => Err(format!("set->list expected a set: {}", a)),
-    None => Err(String::from("set->list expected 1 argument, got none")),
+    Some(a) => Err(format!("&set:to-list expected a set: {}", a)),
+    None => Err(String::from("&set:to-list expected 1 argument, got none")),
   }
 }
 

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -75,8 +75,8 @@ pub fn format_number(xs: &CalcitItems) -> Result<Calcit, String> {
       let size = f64_to_usize(*x)?;
       Ok(Calcit::Str(format!("{n:.*}", size, n = n)))
     }
-    (Some(a), Some(b)) => Err(format!("format-number expected numbers, got: {} {}", a, b)),
-    (_, _) => Err(String::from("format-number expected 2 arguments")),
+    (Some(a), Some(b)) => Err(format!("&number:format expected numbers, got: {} {}", a, b)),
+    (_, _) => Err(String::from("&number:format expected 2 arguments")),
   }
 }
 
@@ -104,16 +104,16 @@ pub fn split_lines(xs: &CalcitItems) -> Result<Calcit, String> {
     _ => Err(String::from("split-lines expected 1 argument, got nothing")),
   }
 }
-pub fn substr(xs: &CalcitItems) -> Result<Calcit, String> {
+pub fn str_slice(xs: &CalcitItems) -> Result<Calcit, String> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Str(s)), Some(Calcit::Number(n))) => match f64_to_usize(*n) {
       Ok(from) => {
         let to: usize = match xs.get(2) {
           Some(Calcit::Number(n2)) => match f64_to_usize(*n2) {
             Ok(idx2) => idx2,
-            Err(e) => return Err(format!("substr expected number, got: {}", e)),
+            Err(e) => return Err(format!("&str:slice expected number, got: {}", e)),
           },
-          Some(a) => return Err(format!("substr expected number, got: {}", a)),
+          Some(a) => return Err(format!("&str:slice expected number, got: {}", a)),
           None => s.chars().count(),
         };
         if from >= to {
@@ -124,8 +124,8 @@ pub fn substr(xs: &CalcitItems) -> Result<Calcit, String> {
       }
       Err(e) => Err(e),
     },
-    (Some(a), Some(b)) => Err(format!("substr expected string and number, got: {} {}", a, b)),
-    (_, _) => Err(format!("substr expected string and numbers, got: {:?}", xs)),
+    (Some(a), Some(b)) => Err(format!("&str:slice expected string and number, got: {} {}", a, b)),
+    (_, _) => Err(format!("&str:slice expected string and numbers, got: {:?}", xs)),
   }
 }
 
@@ -139,8 +139,8 @@ pub fn compare_string(xs: &CalcitItems) -> Result<Calcit, String> {
       };
       Ok(Calcit::Number(v as f64))
     }
-    (Some(a), Some(b)) => Err(format!("compare-string expected 2 strings, got: {}, {}", a, b)),
-    (_, _) => Err(format!("compare-string expected 2 string, got: {:?}", xs)),
+    (Some(a), Some(b)) => Err(format!("&str:compare expected 2 strings, got: {}, {}", a, b)),
+    (_, _) => Err(format!("&str:compare expected 2 string, got: {:?}", xs)),
   }
 }
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -197,7 +197,7 @@
         |drop $ quote
           defn drop (xs n)
             slice xs n (&list:count xs)
-        
+
         |slice $ quote
           defn slice (xs n ? m)
             if (nil? xs) nil
@@ -1285,7 +1285,7 @@
           defrecord! &core-record-class
             :get &record:get
             :get-name &record:get-name
-            :same-kind? &record:matches?
+            :matches? &record:matches?
             :to-map &record:to-map
             :count &record:count
             :contains? &record:contains?

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -377,19 +377,15 @@ fn gen_call_code(
               Some(x) => Some(x.to_owned()),
               None => Some(String::from("return ")),
             };
-            let code = to_js_code(expr, ns, local_defs, file_imports, &next_return_label)?;
+            let try_code = to_js_code(expr, ns, local_defs, file_imports, &next_return_label)?;
             let err_var = js_gensym("errMsg");
             let handler = to_js_code(handler, ns, local_defs, file_imports, &None)?;
 
             call_stack::pop_call_stack();
+            let code = snippets::tmpl_try(err_var, try_code, handler, &next_return_label.unwrap());
             match return_label {
-              Some(_) => Ok(snippets::tmpl_try(err_var, code, handler, "")),
-              None => Ok(snippets::tmpl_fn_wrapper(snippets::tmpl_try(
-                err_var,
-                code,
-                handler,
-                &next_return_label.unwrap(),
-              ))),
+              Some(_) => Ok(code),
+              None => Ok(snippets::tmpl_fn_wrapper(code)),
             }
           }
           (_, _) => Err(format!("try expected 2 nodes, got {:?}", body)),

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -59,25 +59,25 @@ fn escape_var(name: &str) -> String {
       .replace("-", "_")
       // dot might be part of variable `\.`. not confused with syntax
       .replace(".", "_DOT_")
-      .replace("?", "_QUES_")
+      .replace("?", "_$q_")
       .replace("+", "_ADD_")
       .replace("^", "_CRT_")
-      .replace("*", "_STAR_")
-      .replace("&", "_AND_")
-      .replace("{}", "_MAP_")
-      .replace("[]", "_LIST_")
+      .replace("*", "_$s_")
+      .replace("&", "_$n_")
+      .replace("{}", "_$M_")
+      .replace("[]", "_$L_")
       .replace("{", "_CURL_")
       .replace("}", "_CURR_")
       .replace("'", "_SQUO_")
       .replace("[", "_SQRL_")
       .replace("]", "_SQRR_")
-      .replace("!", "_BANG_")
+      .replace("!", "_$x_")
       .replace("%", "_PCT_")
       .replace("/", "_SLSH_")
-      .replace("=", "_EQ_")
+      .replace("=", "_$e_")
       .replace(">", "_GT_")
       .replace("<", "_LT_")
-      .replace(":", "_COL_")
+      .replace(":", "_$o_")
       .replace(";", "_SCOL_")
       .replace("#", "_SHA_")
       .replace("\\", "_BSL_"),
@@ -345,7 +345,7 @@ fn gen_call_code(
         },
 
         "defmacro" => Ok(format!("/* Unexpected macro {} */", xs)),
-        "quasiquote" | "quote-replace" => Ok(format!("(/* Unexpected quasiquote {} */ null)", xs.lisp_str())),
+        "quasiquote" => Ok(format!("(/* Unexpected quasiquote {} */ null)", xs.lisp_str())),
 
         "raise" => {
           // not core syntax, but treat as macro for better debugging experience

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -2,14 +2,14 @@ use crate::builtins::meta::js_gensym;
 
 pub const CALCIT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn tmpl_try(err_var: String, body: String, handler: String) -> String {
+pub fn tmpl_try(err_var: String, body: String, handler: String, return_code: &str) -> String {
   format!(
     "try {{
-  return {}
+  {}
 }} catch ({}) {{
-  return ({})({}.toString())
+  {} ({})({}.toString())
 }}",
-    body, err_var, handler, err_var,
+    body, err_var, return_code, handler, err_var,
   )
 }
 

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -120,12 +120,12 @@ pub fn tmpl_classes_registering() -> String {
   format!(
     "
 $calcit_procs.register_calcit_builtin_classes({{
-  list: _AND_core_list_class,
-  map: _AND_core_map_class,
-  number: _AND_core_number_class,
-  record: _AND_core_record_class,
-  set: _AND_core_set_class,
-  string: _AND_core_string_class,
+  list: _$n_core_list_class,
+  map: _$n_core_map_class,
+  number: _$n_core_number_class,
+  record: _$n_core_record_class,
+  set: _$n_core_set_class,
+  string: _$n_core_string_class,
 }});
 
 let runtimeVersion = $calcit_procs.calcit_version;

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -251,7 +251,7 @@ fn process_list_call(
       }
     }
     (Calcit::Syntax(name, name_ns), _) => match name.as_str() {
-      "quasiquote" | "quote-replace" => Ok((
+      "quasiquote" => Ok((
         preprocess_quasiquote(&name, &name_ns, args, scope_defs, file_ns, program_code)?,
         None,
       )),

--- a/ts-src/calcit-data.ts
+++ b/ts-src/calcit-data.ts
@@ -363,7 +363,7 @@ export let to_js_data = (x: CalcitValue, addColon: boolean = false): any => {
   return x;
 };
 
-export let _AND_map_COL_get = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_map_$o_get = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) {
     throw new Error("map &get takes 2 arguments");
   }
@@ -373,7 +373,7 @@ export let _AND_map_COL_get = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `&get` on this type");
 };
 
-export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
+export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
   if (x === y) {
     return true;
   }
@@ -425,7 +425,7 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
       for (let idx = 0; idx < size; idx++) {
         let xItem = x.get(idx);
         let yItem = y.get(idx);
-        if (!_AND__EQ_(xItem, yItem)) {
+        if (!_$n__$e_(xItem, yItem)) {
           return false;
         }
       }
@@ -442,7 +442,7 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
         if (!y.contains(k)) {
           return false;
         }
-        if (!_AND__EQ_(v, _AND_map_COL_get(y, k))) {
+        if (!_$n__$e_(v, _$n_map_$o_get(y, k))) {
           return false;
         }
       }
@@ -458,7 +458,7 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
   }
   if (x instanceof CalcitTuple) {
     if (y instanceof CalcitTuple) {
-      return _AND__EQ_(x.fst, y.fst) && _AND__EQ_(x.snd, y.snd);
+      return _$n__$e_(x.fst, y.fst) && _$n__$e_(x.snd, y.snd);
     }
     return false;
   }
@@ -472,7 +472,7 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
         // testing by doing iteration is O(n2), could be slow
         // but Set::contains does not satisfy here
         for (let yv of y.value) {
-          if (_AND__EQ_(v, yv)) {
+          if (_$n__$e_(v, yv)) {
             found = true;
             break;
           }
@@ -506,7 +506,7 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
         return false;
       }
       for (let idx in x.fields) {
-        if (!_AND__EQ_(x.values[idx], y.values[idx])) {
+        if (!_$n__$e_(x.values[idx], y.values[idx])) {
           return false;
         }
       }
@@ -518,5 +518,5 @@ export let _AND__EQ_ = (x: CalcitValue, y: CalcitValue): boolean => {
 };
 
 // overwrite internary comparator of ternary-tree
-overwriteComparator(_AND__EQ_);
-overwriteDataComparator(_AND__EQ_);
+overwriteComparator(_$n__$e_);
+overwriteDataComparator(_$n__$e_);

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a2";
+export const calcit_version = "0.4.0-a3";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a1";
+export const calcit_version = "0.4.0-a2";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";
@@ -1022,11 +1022,11 @@ export let cpu_time = (): number => {
   return performance.now();
 };
 
-export let quit = (): void => {
+export let quit_$x_ = (): void => {
   if (inNodeJs) {
     process.exit(1);
   } else {
-    throw new Error("quit()");
+    throw new Error("quit!()");
   }
 };
 

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a3";
+export const calcit_version = "0.4.0-a4";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,23 +1,11 @@
 // CALCIT VERSION
-export const calcit_version = "0.3.39";
+export const calcit_version = "0.4.0-a1";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";
 
 import { CalcitValue } from "./js-primes";
-import {
-  CalcitSymbol,
-  CalcitKeyword,
-  CalcitRef,
-  CalcitFn,
-  CalcitRecur,
-  kwd,
-  refsRegistry,
-  toString,
-  getStringName,
-  to_js_data,
-  _AND__EQ_,
-} from "./calcit-data";
+import { CalcitSymbol, CalcitKeyword, CalcitRef, CalcitFn, CalcitRecur, kwd, refsRegistry, toString, getStringName, to_js_data, _$n__$e_ } from "./calcit-data";
 
 import { fieldsEqual, CalcitRecord } from "./js-record";
 
@@ -94,33 +82,33 @@ export let print = (...xs: CalcitValue[]): void => {
   console.log(xs.map((x) => toString(x, false)).join(" "));
 };
 
-export function _AND_list_COL_count(x: CalcitValue): number {
+export function _$n_list_$o_count(x: CalcitValue): number {
   if (x instanceof CalcitList) return x.len();
 
   throw new Error(`expected a list ${x}`);
 }
-export function _AND_str_COL_count(x: CalcitValue): number {
+export function _$n_str_$o_count(x: CalcitValue): number {
   if (typeof x === "string") return x.length;
 
   throw new Error(`expected a string ${x}`);
 }
-export function _AND_map_COL_count(x: CalcitValue): number {
+export function _$n_map_$o_count(x: CalcitValue): number {
   if (x instanceof CalcitMap) return x.len();
 
   throw new Error(`expected a map ${x}`);
 }
-export function _AND_record_COL_count(x: CalcitValue): number {
+export function _$n_record_$o_count(x: CalcitValue): number {
   if (x instanceof CalcitRecord) return x.fields.length;
 
   throw new Error(`expected a record ${x}`);
 }
-export function _AND_set_COL_count(x: CalcitValue): number {
+export function _$n_set_$o_count(x: CalcitValue): number {
   if (x instanceof CalcitSet) return x.len();
 
   throw new Error(`expected a set ${x}`);
 }
 
-export let _LIST_ = (...xs: CalcitValue[]): CalcitList => {
+export let _$L_ = (...xs: CalcitValue[]): CalcitList => {
   return new CalcitList(xs);
 };
 // single quote as alias for list
@@ -128,7 +116,7 @@ export let _SQUO_ = (...xs: CalcitValue[]): CalcitList => {
   return new CalcitList(xs);
 };
 
-export let _AND__MAP_ = (...xs: CalcitValue[]): CalcitMap => {
+export let _$n__$M_ = (...xs: CalcitValue[]): CalcitMap => {
   if (xs.length % 2 !== 0) {
     throw new Error("&map expects even number of arguments");
   }
@@ -153,19 +141,19 @@ export let deref = (x: CalcitRef): CalcitValue => {
   return a.value;
 };
 
-export let _AND__ADD_ = (x: number, y: number): number => {
+export let _$n__ADD_ = (x: number, y: number): number => {
   return x + y;
 };
 
-export let _AND__STAR_ = (x: number, y: number): number => {
+export let _$n__$s_ = (x: number, y: number): number => {
   return x * y;
 };
 
-export let _AND_str = (x: CalcitValue): string => {
+export let _$n_str = (x: CalcitValue): string => {
   return `${x}`;
 };
 
-export let _AND_str_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_str_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (typeof xs === "string") {
     if (typeof x != "number") {
       throw new Error("Expected number index for detecting");
@@ -180,7 +168,7 @@ export let _AND_str_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): bool
   throw new Error("string `contains?` expected a string");
 };
 
-export let _AND_list_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_list_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitList) {
     if (typeof x != "number") {
       throw new Error("Expected number index for detecting");
@@ -195,19 +183,19 @@ export let _AND_list_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): boo
   throw new Error("list `contains?` expected a list");
 };
 
-export let _AND_map_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_map_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitMap) return xs.contains(x);
 
   throw new Error("map `contains?` expected a map");
 };
 
-export let _AND_record_COL_contains_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_record_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitRecord) return xs.contains(x);
 
   throw new Error("record `contains?` expected a record");
 };
 
-export let _AND_str_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_str_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (typeof xs === "string") {
     if (typeof x !== "string") {
       throw new Error("Expected string");
@@ -218,11 +206,11 @@ export let _AND_str_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): bool
   throw new Error("string includes? expected a string");
 };
 
-export let _AND_list_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_list_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitList) {
     let size = xs.len();
     for (let v of xs.items()) {
-      if (_AND__EQ_(v, x)) {
+      if (_$n__$e_(v, x)) {
         return true;
       }
     }
@@ -232,10 +220,10 @@ export let _AND_list_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): boo
   throw new Error("list includes? expected a list");
 };
 
-export let _AND_map_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_map_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitMap) {
     for (let [k, v] of xs.pairs()) {
-      if (_AND__EQ_(v, x)) {
+      if (_$n__$e_(v, x)) {
         return true;
       }
     }
@@ -245,7 +233,7 @@ export let _AND_map_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): bool
   throw new Error("map includes? expected a map");
 };
 
-export let _AND_set_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+export let _$n_set_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
   if (xs instanceof CalcitSet) {
     return xs.contains(x);
   }
@@ -253,7 +241,7 @@ export let _AND_set_COL_includes_QUES_ = (xs: CalcitValue, x: CalcitValue): bool
   throw new Error("set includes? expected a set");
 };
 
-export let _AND_str_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_str_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
@@ -262,7 +250,7 @@ export let _AND_str_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _AND_list_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_list_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
@@ -271,7 +259,7 @@ export let _AND_list_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _AND_tuple_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_tuple_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
@@ -280,7 +268,7 @@ export let _AND_tuple_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _AND_record_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_record_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
@@ -294,7 +282,7 @@ export let _AND_record_COL_nth = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _AND_record_COL_get = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_record_$o_get = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) {
     throw new Error("record &get takes 2 arguments");
   }
@@ -304,7 +292,7 @@ export let _AND_record_COL_get = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `&get` on this type");
 };
 
-export let _AND_list_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_list_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
   if (xs instanceof CalcitList) {
@@ -315,7 +303,7 @@ export let _AND_list_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: C
   }
   throw new Error("list `assoc` expected a list");
 };
-export let _AND_tuple_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_tuple_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
   if (xs instanceof CalcitTuple) {
@@ -327,14 +315,14 @@ export let _AND_tuple_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: 
 
   throw new Error("tuple `assoc` expected a tuple");
 };
-export let _AND_map_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_map_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
   if (xs instanceof CalcitMap) return xs.assoc(k, v);
 
   throw new Error("map `assoc` expected a map");
 };
-export let _AND_record_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_record_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
   if (xs instanceof CalcitRecord) return xs.assoc(k, v);
@@ -342,7 +330,7 @@ export let _AND_record_COL_assoc = function (xs: CalcitValue, k: CalcitValue, v:
   throw new Error("record `assoc` expected a record");
 };
 
-export let assoc_before = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
+export let _$n_list_$o_assoc_before = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
   if (arguments.length !== 3) {
     throw new Error("assoc takes 3 arguments");
   }
@@ -356,7 +344,7 @@ export let assoc_before = function (xs: CalcitList, k: number, v: CalcitValue): 
   throw new Error("Does not support `assoc-before` on this type");
 };
 
-export let assoc_after = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
+export let _$n_list_$o_assoc_after = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
   if (arguments.length !== 3) {
     throw new Error("assoc takes 3 arguments");
   }
@@ -370,7 +358,7 @@ export let assoc_after = function (xs: CalcitList, k: number, v: CalcitValue): C
   throw new Error("Does not support `assoc-after` on this type");
 };
 
-export let _AND_list_COL_dissoc = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_list_$o_dissoc = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("dissoc takes 2 arguments");
 
   if (xs instanceof CalcitList) {
@@ -381,7 +369,7 @@ export let _AND_list_COL_dissoc = function (xs: CalcitValue, k: CalcitValue) {
 
   throw new Error("`dissoc` expected a list");
 };
-export let _AND_map_COL_dissoc = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_map_$o_dissoc = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("dissoc takes 2 arguments");
 
   if (xs instanceof CalcitMap) return xs.dissoc(k);
@@ -389,7 +377,7 @@ export let _AND_map_COL_dissoc = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("`dissoc` expected a map");
 };
 
-export let reset_BANG_ = (a: CalcitRef, v: CalcitValue): null => {
+export let reset_$x_ = (a: CalcitRef, v: CalcitValue): null => {
   if (!(a instanceof CalcitRef)) {
     throw new Error("Expected ref for reset!");
   }
@@ -441,25 +429,25 @@ export let range = (n: number, m: number, m2: number): CalcitList => {
   return result;
 };
 
-export function _AND_list_COL_empty_QUES_(xs: CalcitValue): boolean {
+export function _$n_list_$o_empty_$q_(xs: CalcitValue): boolean {
   if (xs instanceof CalcitList) return xs.isEmpty();
   throw new Error(`expected a list ${xs}`);
 }
-export function _AND_str_COL_empty_QUES_(xs: CalcitValue): boolean {
+export function _$n_str_$o_empty_$q_(xs: CalcitValue): boolean {
   if (typeof xs == "string") return xs.length == 0;
   throw new Error(`expected a string ${xs}`);
 }
-export function _AND_map_COL_empty_QUES_(xs: CalcitValue): boolean {
+export function _$n_map_$o_empty_$q_(xs: CalcitValue): boolean {
   if (xs instanceof CalcitMap) return xs.isEmpty();
 
   throw new Error(`expected a list ${xs}`);
 }
-export function _AND_set_COL_empty_QUES_(xs: CalcitValue): boolean {
+export function _$n_set_$o_empty_$q_(xs: CalcitValue): boolean {
   if (xs instanceof CalcitSet) return xs.len() === 0;
   throw new Error(`expected a list ${xs}`);
 }
 
-export let _AND_list_COL_first = (xs: CalcitValue): CalcitValue => {
+export let _$n_list_$o_first = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitList) {
     if (xs.isEmpty()) {
       return null;
@@ -469,14 +457,14 @@ export let _AND_list_COL_first = (xs: CalcitValue): CalcitValue => {
   console.error(xs);
   throw new Error("Expected a list");
 };
-export let _AND_str_COL_first = (xs: CalcitValue): CalcitValue => {
+export let _$n_str_$o_first = (xs: CalcitValue): CalcitValue => {
   if (typeof xs === "string") {
     return xs[0];
   }
   console.error(xs);
   throw new Error("Expected a string");
 };
-export let _AND_map_COL_first = (xs: CalcitValue): CalcitValue => {
+export let _$n_map_$o_first = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitMap) {
     // TODO order may not be stable enough
     let ys = xs.pairs();
@@ -489,7 +477,7 @@ export let _AND_map_COL_first = (xs: CalcitValue): CalcitValue => {
   console.error(xs);
   throw new Error("Expected a map");
 };
-export let _AND_set_COL_first = (xs: CalcitValue): CalcitValue => {
+export let _$n_set_$o_first = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitSet) {
     return xs.first();
   }
@@ -509,7 +497,7 @@ export let timeout_call = (duration: number, f: CalcitFn): null => {
   return null;
 };
 
-export let _AND_list_COL_rest = (xs: CalcitValue): CalcitValue => {
+export let _$n_list_$o_rest = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitList) {
     if (xs.len() === 0) {
       return null;
@@ -520,19 +508,19 @@ export let _AND_list_COL_rest = (xs: CalcitValue): CalcitValue => {
   throw new Error("Expected a list");
 };
 
-export let _AND_str_COL_rest = (xs: CalcitValue): CalcitValue => {
+export let _$n_str_$o_rest = (xs: CalcitValue): CalcitValue => {
   if (typeof xs === "string") return xs.substr(1);
 
   console.error(xs);
   throw new Error("Expects a string");
 };
-export let _AND_set_COL_rest = (xs: CalcitValue): CalcitValue => {
+export let _$n_set_$o_rest = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitSet) return xs.rest();
 
   console.error(xs);
   throw new Error("Expect a set");
 };
-export let _AND_map_COL_rest = (xs: CalcitValue): CalcitValue => {
+export let _$n_map_$o_rest = (xs: CalcitValue): CalcitValue => {
   if (xs instanceof CalcitMap) {
     if (xs.len() > 0) {
       let k0 = xs.pairs()[0][0];
@@ -549,7 +537,7 @@ export let recur = (...xs: CalcitValue[]): CalcitRecur => {
   return new CalcitRecur(xs);
 };
 
-export let _AND_get_calcit_backend = () => {
+export let _$n_get_calcit_backend = () => {
   return kwd("js");
 };
 
@@ -604,7 +592,7 @@ export let initCrTernary = (x: string): CalcitValue => {
   return null;
 };
 
-export let _SHA__MAP_ = (...xs: CalcitValue[]): CalcitValue => {
+export let _SHA__$M_ = (...xs: CalcitValue[]): CalcitValue => {
   var result = new Set<CalcitValue>();
   for (let idx in xs) {
     result.add(xs[idx]);
@@ -614,18 +602,18 @@ export let _SHA__MAP_ = (...xs: CalcitValue[]): CalcitValue => {
 
 let idCounter = 0;
 
-export let generate_id_BANG_ = (): string => {
+export let generate_id_$x_ = (): string => {
   // TODO use nanoid.. this code is wrong
   idCounter = idCounter + 1;
   return `gen_id_${idCounter}`;
 };
 
-export let display_stack = (): null => {
+export let _$n_display_stack = (): null => {
   console.trace();
   return null;
 };
 
-export let slice = (xs: CalcitList, from: number, to: number): CalcitList => {
+export let _$n_list_$o_slice = (xs: CalcitList, from: number, to: number): CalcitList => {
   if (xs == null) {
     return null;
   }
@@ -640,7 +628,7 @@ export let slice = (xs: CalcitList, from: number, to: number): CalcitList => {
   return xs.slice(from, to);
 };
 
-export let concat = (...lists: CalcitList[]): CalcitList => {
+export let _$n_list_$o_concat = (...lists: CalcitList[]): CalcitList => {
   let result: CalcitList = new CalcitList([]);
   for (let item of lists) {
     if (item == null) {
@@ -659,7 +647,7 @@ export let concat = (...lists: CalcitList[]): CalcitList => {
   return result;
 };
 
-export let reverse = (xs: CalcitList): CalcitList => {
+export let _$n_list_$o_reverse = (xs: CalcitList): CalcitList => {
   if (xs == null) {
     return null;
   }
@@ -671,25 +659,25 @@ export let format_ternary_tree = (): null => {
   return null;
 };
 
-export let _AND__GT_ = (a: number, b: number): boolean => {
+export let _$n__GT_ = (a: number, b: number): boolean => {
   return a > b;
 };
-export let _AND__LT_ = (a: number, b: number): boolean => {
+export let _$n__LT_ = (a: number, b: number): boolean => {
   return a < b;
 };
-export let _AND__ = (a: number, b: number): number => {
+export let _$n__ = (a: number, b: number): number => {
   return a - b;
 };
-export let _AND__SLSH_ = (a: number, b: number): number => {
+export let _$n__SLSH_ = (a: number, b: number): number => {
   return a / b;
 };
-export let rem = (a: number, b: number): number => {
+export let _$n_number_$o_rem = (a: number, b: number): number => {
   return a % b;
 };
-export let integer_QUES_ = (a: number) => {
+export let round_$q_ = (a: number) => {
   return a == Math.round(a);
 };
-export let _AND_str_concat = (a: string, b: string) => {
+export let _$n_str_$o_concat = (a: string, b: string) => {
   return `${toString(a, false)}${toString(b, false)}`;
 };
 export let sort = (xs: CalcitList, f: CalcitFn): CalcitList => {
@@ -727,7 +715,7 @@ export let floor = (n: number): number => {
   return Math.floor(n);
 };
 
-export let _AND_merge = (a: CalcitValue, b: CalcitMap): CalcitValue => {
+export let _$n_merge = (a: CalcitValue, b: CalcitMap): CalcitValue => {
   if (a == null) {
     return b;
   }
@@ -762,7 +750,7 @@ export let _AND_merge = (a: CalcitValue, b: CalcitMap): CalcitValue => {
   throw new Error("Expected map or record");
 };
 
-export let _AND_merge_non_nil = (a: CalcitMap, b: CalcitMap): CalcitMap => {
+export let _$n_merge_non_nil = (a: CalcitMap, b: CalcitMap): CalcitMap => {
   if (a == null) {
     return b;
   }
@@ -814,7 +802,7 @@ export let ceil = (n: number) => {
 export let round = (n: number) => {
   return Math.round(n);
 };
-export let fractional = (n: number) => {
+export let _$n_number_$o_fract = (n: number) => {
   return n - Math.floor(n);
 };
 export let sqrt = (n: number) => {
@@ -823,7 +811,7 @@ export let sqrt = (n: number) => {
 
 // Set functions
 
-export let _AND_include = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
+export let _$n_include = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
   if (!(xs instanceof CalcitSet)) {
     throw new Error("Expected a set");
   }
@@ -833,7 +821,7 @@ export let _AND_include = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
   return xs.include(y);
 };
 
-export let _AND_exclude = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
+export let _$n_exclude = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
   if (!(xs instanceof CalcitSet)) {
     throw new Error("Expected a set");
   }
@@ -843,7 +831,7 @@ export let _AND_exclude = (xs: CalcitSet, y: CalcitValue): CalcitSet => {
   return xs.exclude(y);
 };
 
-export let _AND_difference = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
+export let _$n_difference = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   if (!(xs instanceof CalcitSet)) {
     throw new Error("Expected a set");
   }
@@ -853,7 +841,7 @@ export let _AND_difference = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   return xs.difference(ys);
 };
 
-export let _AND_union = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
+export let _$n_union = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   if (!(xs instanceof CalcitSet)) {
     throw new Error("Expected a set");
   }
@@ -863,7 +851,7 @@ export let _AND_union = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   return xs.union(ys);
 };
 
-export let _AND_intersection = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
+export let _$n_set_$o_intersection = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   if (!(xs instanceof CalcitSet)) {
     throw new Error("Expected a set");
   }
@@ -873,7 +861,7 @@ export let _AND_intersection = (xs: CalcitSet, ys: CalcitSet): CalcitSet => {
   return xs.intersection(ys);
 };
 
-export let _AND_str_COL_replace = (x: string, y: string, z: string): string => {
+export let _$n_str_$o_replace = (x: string, y: string, z: string): string => {
   var result = x;
   while (result.indexOf(y) >= 0) {
     result = result.replace(y, z);
@@ -887,7 +875,7 @@ export let split = (xs: string, x: string): CalcitList => {
 export let split_lines = (xs: string): CalcitList => {
   return new CalcitList(xs.split("\n"));
 };
-export let substr = (xs: string, m: number, n: number): string => {
+export let _$n_str_$o_slice = (xs: string, m: number, n: number): string => {
   if (n <= m) {
     console.warn("endIndex too small");
     return "";
@@ -895,7 +883,7 @@ export let substr = (xs: string, m: number, n: number): string => {
   return xs.substring(m, n);
 };
 
-export let _AND_str_COL_find_index = (x: string, y: string): number => {
+export let _$n_str_$o_find_index = (x: string, y: string): number => {
   return x.indexOf(y);
 };
 
@@ -925,7 +913,7 @@ export let trim = (x: string, c: string): string => {
   return x.trim();
 };
 
-export let format_number = (x: number, n: number): string => {
+export let _$n_number_$o_format = (x: number, n: number): string => {
   return x.toFixed(n);
 };
 
@@ -961,7 +949,7 @@ export let stringify_json = (x: CalcitValue, addColon: boolean = false): string 
   return JSON.stringify(to_js_data(x, addColon));
 };
 
-export let set__GT_list = (x: CalcitSet): CalcitList => {
+export let _$n_set_$o_to_list = (x: CalcitSet): CalcitList => {
   var result: CalcitValue[] = [];
   x.value.forEach((item) => {
     result.push(item);
@@ -1065,18 +1053,18 @@ export let turn_string = (x: CalcitValue): string => {
   throw new Error("Unexpected data to turn string");
 };
 
-export let identical_QUES_ = (x: CalcitValue, y: CalcitValue): boolean => {
+export let identical_$q_ = (x: CalcitValue, y: CalcitValue): boolean => {
   return x === y;
 };
 
-export let starts_with_QUES_ = (xs: string, y: string): boolean => {
+export let starts_with_$q_ = (xs: string, y: string): boolean => {
   return xs.startsWith(y);
 };
-export let ends_with_QUES_ = (xs: string, y: string): boolean => {
+export let ends_with_$q_ = (xs: string, y: string): boolean => {
   return xs.endsWith(y);
 };
 
-export let blank_QUES_ = (x: string): boolean => {
+export let blank_$q_ = (x: string): boolean => {
   if (x == null) {
     return true;
   }
@@ -1087,7 +1075,7 @@ export let blank_QUES_ = (x: string): boolean => {
   }
 };
 
-export let compare_string = (x: string, y: string) => {
+export let _$n_str_$o_compare = (x: string, y: string) => {
   if (x < y) {
     return -1;
   }
@@ -1112,44 +1100,44 @@ export let listToArray = (xs: CalcitList): Array<CalcitValue> => {
   }
 };
 
-export let number_QUES_ = (x: CalcitValue): boolean => {
+export let number_$q_ = (x: CalcitValue): boolean => {
   return typeof x === "number";
 };
-export let string_QUES_ = (x: CalcitValue): boolean => {
+export let string_$q_ = (x: CalcitValue): boolean => {
   return typeof x === "string";
 };
-export let bool_QUES_ = (x: CalcitValue): boolean => {
+export let bool_$q_ = (x: CalcitValue): boolean => {
   return typeof x === "boolean";
 };
-export let nil_QUES_ = (x: CalcitValue): boolean => {
+export let nil_$q_ = (x: CalcitValue): boolean => {
   return x == null;
 };
-export let keyword_QUES_ = (x: CalcitValue): boolean => {
+export let keyword_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitKeyword;
 };
-export let map_QUES_ = (x: CalcitValue): boolean => {
+export let map_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitMap;
 };
-export let list_QUES_ = (x: CalcitValue): boolean => {
+export let list_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitList;
 };
-export let set_QUES_ = (x: CalcitValue): boolean => {
+export let set_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitSet;
 };
-export let fn_QUES_ = (x: CalcitValue): boolean => {
+export let fn_$q_ = (x: CalcitValue): boolean => {
   return typeof x === "function";
 };
-export let ref_QUES_ = (x: CalcitValue): boolean => {
+export let ref_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitRef;
 };
-export let record_QUES_ = (x: CalcitValue): boolean => {
+export let record_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitRecord;
 };
-export let tuple_QUES_ = (x: CalcitValue): boolean => {
+export let tuple_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitTuple;
 };
 
-export let escape = (x: string) => JSON.stringify(x);
+export let _$n_str_$o_escape = (x: string) => JSON.stringify(x);
 
 export let read_file = (path: string): string => {
   if (inNodeJs) {
@@ -1179,7 +1167,7 @@ export let parse_cirru_edn = (code: string) => {
 };
 
 /** return in seconds, like from Nim */
-export let now_BANG_ = () => {
+export let get_time_$x_ = () => {
   return Date.now() / 1000;
 };
 
@@ -1215,7 +1203,7 @@ export let js_array = (...xs: CalcitValue[]): CalcitValue[] => {
   return xs;
 };
 
-export let _AND_js_object = (...xs: CalcitValue[]): Record<string, CalcitValue> => {
+export let _$n_js_object = (...xs: CalcitValue[]): Record<string, CalcitValue> => {
   if (xs.length % 2 !== 0) {
     throw new Error("&js-object expects even number of arguments");
   }
@@ -1243,7 +1231,7 @@ export let format_time = (timeSecNumber: number, format?: string): string => {
   return new Date(timeSecNumber * 1000).toISOString();
 };
 
-export let _COL__COL_ = (a: CalcitValue, b: CalcitValue): CalcitTuple => {
+export let _$o__$o_ = (a: CalcitValue, b: CalcitValue): CalcitTuple => {
   return new CalcitTuple(a, b);
 };
 
@@ -1299,7 +1287,7 @@ export function invoke_method(p: string) {
   };
 }
 
-export let _AND_map_COL_to_list = (m: CalcitValue): CalcitList => {
+export let _$n_map_$o_to_list = (m: CalcitValue): CalcitList => {
   if (m instanceof CalcitMap) {
     let ys = [];
     for (let pair of m.pairs()) {
@@ -1311,7 +1299,7 @@ export let _AND_map_COL_to_list = (m: CalcitValue): CalcitList => {
   }
 };
 
-export let _AND_compare = (a: CalcitValue, b: CalcitValue): number => {
+export let _$n_compare = (a: CalcitValue, b: CalcitValue): number => {
   if (a < b) {
     return -1;
   } else if (a > b) {
@@ -1330,14 +1318,14 @@ let unavailableProc = (...xs: []) => {
 };
 
 // not available for calcit-js
-export let _AND_reset_gensym_index_BANG_ = unavailableProc;
+export let _$n_reset_gensym_index_$x_ = unavailableProc;
 export let dbt__GT_point = unavailableProc;
 export let dbt_digits = unavailableProc;
 export let dual_balanced_ternary = unavailableProc;
 export let gensym = unavailableProc;
 export let macroexpand = unavailableProc;
 export let macroexpand_all = unavailableProc;
-export let _AND_get_calcit_running_mode = unavailableProc;
+export let _$n_get_calcit_running_mode = unavailableProc;
 
 // already handled in code emitter
 export let raise = unavailableProc;

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a4";
+export const calcit_version = "0.4.0-a5";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";

--- a/ts-src/custom-formatter.ts
+++ b/ts-src/custom-formatter.ts
@@ -30,7 +30,7 @@ let embedObject = (x: CalcitValue) => {
   ];
 };
 
-export let load_console_formatter_BANG_ = () => {
+export let load_console_formatter_$x_ = () => {
   if (typeof window === "object") {
     window["devtoolsFormatters"] = [
       {

--- a/ts-src/js-cirru.ts
+++ b/ts-src/js-cirru.ts
@@ -10,7 +10,7 @@ import { CalcitKeyword, CalcitSymbol, kwd } from "./calcit-data";
 
 type CirruEdnFormat = string | CirruEdnFormat[];
 
-export let write_cirru = (data: CalcitList, useInline: boolean): string => {
+export let format_cirru = (data: CalcitList, useInline: boolean): string => {
   let chunk = toWriterNode(data);
   if (!Array.isArray(chunk)) {
     throw new Error("Expected data of list");
@@ -166,7 +166,7 @@ export let extract_cirru_edn = (x: CirruEdnFormat): CalcitValue => {
   throw new Error("Unexpected data from cirru-edn");
 };
 
-export let write_cirru_edn = (data: CalcitValue, useInline: boolean = true): string => {
+export let format_cirru_edn = (data: CalcitValue, useInline: boolean = true): string => {
   if (data == null) {
     return "\ndo nil" + "\n";
   }

--- a/ts-src/js-record.ts
+++ b/ts-src/js-record.ts
@@ -91,7 +91,7 @@ export let fieldsEqual = (xs: Array<string>, ys: Array<string>): boolean => {
   return true;
 };
 
-export let _AND__PCT__MAP_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
+export let _$n__PCT__$M_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
   if (proto instanceof CalcitRecord) {
     if (xs.length % 2 !== 0) {
       throw new Error("Expected even number of key/value");
@@ -127,7 +127,7 @@ export let _AND__PCT__MAP_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): Ca
   }
 };
 
-export let get_record_name = (x: CalcitRecord): string => {
+export let _$n_record_$o_get_name = (x: CalcitRecord): string => {
   if (x instanceof CalcitRecord) {
     return x.name;
   } else {
@@ -135,7 +135,7 @@ export let get_record_name = (x: CalcitRecord): string => {
   }
 };
 
-export let make_record = (proto: CalcitValue, data: CalcitValue): CalcitValue => {
+export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): CalcitValue => {
   if (proto instanceof CalcitRecord) {
     if (data instanceof CalcitRecord) {
       if (fieldsEqual(proto.fields, data.fields)) {
@@ -178,7 +178,7 @@ export let make_record = (proto: CalcitValue, data: CalcitValue): CalcitValue =>
   }
 };
 
-export let turn_map = (x: CalcitValue): CalcitValue => {
+export let _$n_record_$o_to_map = (x: CalcitValue): CalcitValue => {
   if (x instanceof CalcitRecord) {
     var dict: Array<[CalcitValue, CalcitValue]> = [];
     for (let idx in x.fields) {
@@ -190,7 +190,7 @@ export let turn_map = (x: CalcitValue): CalcitValue => {
   }
 };
 
-export let relevant_record_QUES_ = (x: CalcitValue, y: CalcitValue): boolean => {
+export let _$n_record_$o_matches_$q_ = (x: CalcitValue, y: CalcitValue): boolean => {
   if (!(x instanceof CalcitRecord)) {
     throw new Error("Expected record");
   }


### PR DESCRIPTION
This PR contains many changes to APIs, which will probably break existing projects. Benefit is some quirky API names got unified. There are still some rough edges need to be polished in future versions of `0.4.x`.

Another change is the js emitted, some escaping names:

- `_AND_` -> `_$n_`
- `_COL_` -> `_$o_`
- `_BANG_` -> `_$x_`
- `_MAP_` -> `_$M_`
- `_LIST_` -> `_$L_`
