### PR TITLE
attach value in thunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a13"
+version = "0.4.0-a14"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a13"
+version = "0.4.0-a14"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a13",
+  "version": "0.4.0-a14",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -998,7 +998,7 @@ fn gen_js_func(
 fn contains_symbol(xs: &Calcit, y: &str) -> bool {
   match xs {
     Calcit::Symbol(s, ..) => s == y,
-    Calcit::Thunk(code) => contains_symbol(code, y),
+    Calcit::Thunk(code, _) => contains_symbol(code, y),
     Calcit::Fn(_, _, _, _, _, body) => {
       for x in body {
         if contains_symbol(x, y) {
@@ -1172,7 +1172,7 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
           defs_code.push_str(&gen_js_func(&def, args, code, &ns, true, &def_names, &file_imports)?);
           call_stack::pop_call_stack();
         }
-        Calcit::Thunk(code) => {
+        Calcit::Thunk(code, _) => {
           // TODO need topological sorting for accuracy
           // values are called directly, put them after fns
           call_stack::push_call_stack(&ns, &def, StackKind::Codegen, (**code).to_owned(), &im::vector![]);
@@ -1191,10 +1191,10 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
           // should he handled inside compiler
         }
         Calcit::Bool(_) | Calcit::Number(_) => {
-          println!("[Warn] `{}/{} = {}` skipped, probably used by macro", ns, def, f)
+          println!("[Warn] expected thunk, got macro. skipped `{}/{} {}`", ns, def, f)
         }
         _ => {
-          println!("[Warn] unhandled `{}/{} = {}` for generating js def", ns, def, f)
+          println!("[Warn] expected thunk for js, skipped `{}/{} {}`", ns, def, f)
         }
       }
     }

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -144,7 +144,7 @@ fn dump_code(code: &Calcit) -> serde_json::Value {
         "name": name,
       })
     }
-    Calcit::Thunk(code) => dump_code(code),
+    Calcit::Thunk(code, _) => dump_code(code),
     Calcit::List(xs) => {
       let mut ys: Vec<serde_json::Value> = vec![];
       for x in xs {

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -46,7 +46,7 @@ pub fn preprocess_ns_def(
               Err(e) => return Err(e),
             }
           } else {
-            Calcit::Thunk(Box::new(resolved_code))
+            Calcit::Thunk(Box::new(resolved_code), None)
           };
           // println!("\nwriting value to: {}/{} {:?}", ns, def, v);
           program::write_evaled_def(ns, def, v.clone())?;

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a13";
+export const calcit_version = "0.4.0-a14";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";


### PR DESCRIPTION
thunk are required since jsgen and irgen need raw code. there might be chance that thunk are called during preprocessing. in previous implementation, thunk are replaced after evaluated. now the thunk is retained. Might have performance costs since I don't master usages of `Box`.
