### PR TITLE
add --watch-dir ; refactor entry code a bit; ready for 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.0-a14"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.0-a14"
+version = "0.4.0"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.0-a14",
+  "version": "0.4.0",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^15.12.2",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
 use std::time::Duration;
 use std::time::Instant;
@@ -9,11 +9,27 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use calcit_runner;
 use calcit_runner::{builtins, call_stack, cli_args, codegen, program, runner, snapshot, util};
 
+struct ProgramSettings {
+  entry_path: PathBuf,
+  emit_path: String,
+  reload_libs: bool,
+  emit_js: bool,
+  emit_ir: bool,
+}
+
 fn main() -> Result<(), String> {
   builtins::effects::init_effects_states();
   let cli_matches = cli_args::parse_cli();
-
+  let settings = ProgramSettings {
+    // has default value
+    entry_path: Path::new(cli_matches.value_of("input").unwrap()).to_owned(),
+    emit_path: cli_matches.value_of("emit-path").or(Some("js-out")).unwrap().to_owned(),
+    reload_libs: cli_matches.is_present("reload-libs"),
+    emit_js: cli_matches.is_present("emit-js"),
+    emit_ir: cli_matches.is_present("emit-ir"),
+  };
   let mut eval_once = cli_matches.is_present("once");
+  let assets_watch = cli_matches.value_of("watch-dir");
 
   println!("calcit_runner version: {}", cli_args::CALCIT_VERSION);
 
@@ -31,28 +47,19 @@ fn main() -> Result<(), String> {
     }
   } else {
     // load entry file
-    let entry_path = Path::new(cli_matches.value_of("input").unwrap());
-    let content = fs::read_to_string(entry_path).expect(&format!("expected Cirru snapshot: {:?}", entry_path));
+    let content = fs::read_to_string(settings.entry_path.to_owned())
+      .expect(&format!("expected Cirru snapshot: {:?}", settings.entry_path));
     let data = cirru_edn::parse(&content)?;
     // println!("reading: {}", content);
     snapshot = snapshot::load_snapshot_data(data)?;
-
     // attach modules
     for module_path in &snapshot.configs.modules {
-      let module_data = calcit_runner::load_module(&module_path, entry_path.parent().unwrap())?;
+      let module_data = calcit_runner::load_module(&module_path, settings.entry_path.parent().unwrap())?;
       for (k, v) in &module_data.files {
         snapshot.files.insert(k.clone(), v.clone());
       }
     }
   }
-
-  // attach core
-  for (k, v) in core_snapshot.files {
-    snapshot.files.insert(k.clone(), v.clone());
-  }
-
-  let mut program_code = program::extract_program_data(&snapshot)?;
-
   let init_fn = cli_matches
     .value_of("init-fn")
     .or(Some(&snapshot.configs.init_fn))
@@ -61,7 +68,12 @@ fn main() -> Result<(), String> {
     .value_of("reload-fn")
     .or(Some(&snapshot.configs.reload_fn))
     .unwrap();
-  let emit_path = cli_matches.value_of("emit-path").or(Some("js-out")).unwrap();
+  // attach core
+  for (k, v) in core_snapshot.files {
+    snapshot.files.insert(k.clone(), v.clone());
+  }
+
+  let mut program_code = program::extract_program_data(&snapshot)?;
 
   // make sure builtin classes are touched
   runner::preprocess::preprocess_ns_def(
@@ -72,10 +84,10 @@ fn main() -> Result<(), String> {
     None,
   )?;
 
-  let task = if cli_matches.is_present("emit-js") {
-    run_codegen(&init_fn, &reload_fn, &program_code, &emit_path, false)
-  } else if cli_matches.is_present("emit-ir") {
-    run_codegen(&init_fn, &reload_fn, &program_code, &emit_path, true)
+  let task = if settings.emit_js {
+    run_codegen(&init_fn, &reload_fn, &program_code, &settings.emit_path, false)
+  } else if settings.emit_ir {
+    run_codegen(&init_fn, &reload_fn, &program_code, &settings.emit_path, true)
   } else {
     let started_time = Instant::now();
 
@@ -101,84 +113,103 @@ fn main() -> Result<(), String> {
   if !eval_once {
     println!("\nRunner: in watch mode...\n");
     let (tx, rx) = channel();
-    let entry_path = Path::new(cli_matches.value_of("input").unwrap());
     let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(200)).unwrap();
 
-    let inc_path = entry_path.parent().unwrap().join(".compact-inc.cirru");
+    let inc_path = settings.entry_path.parent().unwrap().join(".compact-inc.cirru");
     if !inc_path.exists() {
       fs::write(&inc_path, "").map_err(|e| -> String { e.to_string() })?;
     }
 
     watcher.watch(&inc_path, RecursiveMode::NonRecursive).unwrap();
 
+    if let Some(assets_folder) = assets_watch {
+      watcher.watch(assets_folder, RecursiveMode::Recursive).unwrap();
+      println!("assets to watch: {}", assets_folder);
+    }
+
     loop {
+      let mut change_happened = false;
       match rx.recv() {
         Ok(event) => {
-          // println!("event: {:?}", event);
           match event {
             notify::DebouncedEvent::NoticeWrite(..) => {
               // ignored
             }
             notify::DebouncedEvent::Write(_) => {
-              println!("\n-------- file change --------\n");
-              call_stack::clear_stack();
-
-              // Steps:
-              // 1. load changes file, and patch to program_code
-              // 2. clears evaled states, gensym counter
-              // 3. rerun program, and catch error
-
-              // load new program code
-              let content = fs::read_to_string(&inc_path).unwrap();
-              if content.trim() == "" {
-                println!("failed re-compiling, got empty inc file");
-                continue;
-              }
-              let data = cirru_edn::parse(&content)?;
-              let changes = snapshot::load_changes_info(data.clone())?;
-
-              // println!("\ndata: {}", &data);
-              // println!("\nchanges: {:?}", changes);
-              let new_code = program::apply_code_changes(&program_code, &changes)?;
-              // println!("\nprogram code: {:?}", new_code);
-
-              // clear data in evaled states
-              let reload_libs = cli_matches.is_present("reload-libs");
-              program::clear_all_program_evaled_defs(&init_fn, &reload_fn, reload_libs)?;
-              builtins::meta::force_reset_gensym_index()?;
-
-              let task = if cli_matches.is_present("emit-js") {
-                run_codegen(&init_fn, &reload_fn, &new_code, &emit_path, false)
-              } else if cli_matches.is_present("emit-ir") {
-                run_codegen(&init_fn, &reload_fn, &new_code, &emit_path, true)
-              } else {
-                // run from `reload_fn` after reload
-                let started_time = Instant::now();
-                let v = calcit_runner::run_program(&reload_fn, im::vector![], &new_code)?;
-                let duration = Instant::now().duration_since(started_time);
-                println!("took {}ms: {}", duration.as_micros() as f64 / 1000.0, v);
-                Ok(())
-              };
-
-              match task {
-                Ok(_) => {}
-                Err(e) => {
-                  println!("\nfailed to reload, {}", e)
-                }
-              }
-
-              // overwrite previous state
-              program_code = new_code;
+              // mark state dirty
+              change_happened = true;
             }
             _ => println!("other file event: {:?}, ignored", event),
           }
         }
         Err(e) => println!("watch error: {:?}", e),
       }
+      if change_happened {
+        // load new program code
+        let content = fs::read_to_string(&inc_path).unwrap();
+        if content.trim() == "" {
+          println!("failed re-compiling, got empty inc file");
+          continue;
+        }
+        recall_program(&mut program_code, &content, init_fn, reload_fn, &settings)?;
+      }
     }
   } else {
     Ok(())
   }
+}
+
+fn recall_program(
+  program_code: &mut program::ProgramCodeData,
+  content: &str,
+  init_fn: &str,
+  reload_fn: &str,
+  settings: &ProgramSettings,
+) -> Result<(), String> {
+  println!("\n-------- file change --------\n");
+  call_stack::clear_stack();
+
+  // Steps:
+  // 1. load changes file, and patch to program_code
+  // 2. clears evaled states, gensym counter
+  // 3. rerun program, and catch error
+
+  let data = cirru_edn::parse(&content)?;
+  let changes = snapshot::load_changes_info(data.clone())?;
+
+  // println!("\ndata: {}", &data);
+  // println!("\nchanges: {:?}", changes);
+  let new_code = program::apply_code_changes(&program_code, &changes)?;
+  // println!("\nprogram code: {:?}", new_code);
+
+  // clear data in evaled states
+  program::clear_all_program_evaled_defs(&init_fn, &reload_fn, settings.reload_libs)?;
+  builtins::meta::force_reset_gensym_index()?;
+
+  let task = if settings.emit_js {
+    run_codegen(&init_fn, &reload_fn, &new_code, &settings.emit_path, false)
+  } else if settings.emit_ir {
+    run_codegen(&init_fn, &reload_fn, &new_code, &settings.emit_path, true)
+  } else {
+    // run from `reload_fn` after reload
+    let started_time = Instant::now();
+    let v = calcit_runner::run_program(&reload_fn, im::vector![], &new_code)?;
+    let duration = Instant::now().duration_since(started_time);
+    println!("took {}ms: {}", duration.as_micros() as f64 / 1000.0, v);
+    Ok(())
+  };
+
+  match task {
+    Ok(_) => {}
+    Err(e) => {
+      println!("\nfailed to reload, {}", e)
+    }
+  }
+
+  // overwrite previous state
+  *program_code = new_code;
+
+  Ok(())
 }
 
 fn run_codegen(

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -60,6 +60,12 @@ pub fn parse_cli<'a>() -> clap::ArgMatches<'a> {
         .takes_value(true),
     )
     .arg(
+      clap::Arg::with_name("watch-dir")
+        .help("a folder of assets that also being watched")
+        .long("watch-dir")
+        .takes_value(true),
+    )
+    .arg(
       clap::Arg::with_name("reload-libs")
         .help("reload libs data during code reload")
         .long("reload-libs")

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.0-a14";
+export const calcit_version = "0.4.0";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";


### PR DESCRIPTION
new option `--watch-dir contents/` is used for watching changes from inlined assets. a cheaper way of shadow-cljs resource inlining.

`0.4.0` is released. the code is robust enough compared to `0.3.x`. Still have bugs though.
