### PR TITLE
refine js recursion implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.16"
+version = "0.4.17"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^16.4.13",

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -67,9 +67,9 @@ pub fn tmpl_tail_recursion(
     "{async_prefix}function {name}({args_code}) {{
   {check_args}
   {spreading_code}
-  let {ret_var} = null;
   let {times_var} = 0;
   while(true) {{ /* Tail Recursion */
+    let {ret_var} = null;
     if ({times_var} > 100000) throw new Error('tail recursion not stopping');
     {body}
     if ({ret_var} instanceof {var_prefix}CalcitRecur) {{

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.16";
+export const calcit_version = "0.4.17";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";


### PR DESCRIPTION
some chance the body will not return, which means that `ret_var` will not not assigned, which caused infinite loop.

for example:

```js
if ($calcit.empty_$q_($calcit.rest(xs))) {
  console.log($calcit.printable("All finished.")); // <--------
 } else {
  ret_AUTO_2 =$calcit.recur($calcit.rest(xs), $calcit.inc(c))
}

    if (ret_AUTO_2 instanceof $calcit.CalcitRecur) {
      
if (ret_AUTO_2.args.length !== 2) throw new Error('argument sizes do not match');
      [ xs, c ] = ret_AUTO_2.args;
      
      times_AUTO_3 += 1;
      continue;
    } else {
      return ret_AUTO_2;
    }
  }

```

after this fix, `ret_AUTO_2` becomes a local variable, then it's okay.