### PR TITLE
enforce a stable order of generated keywords in js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "calcit_runner"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "cirru_edn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.4.26"
+version = "0.4.27"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^16.7.2",

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.4.26";
+export const calcit_version = "0.4.27";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse } from "@cirru/parser.ts";


### PR DESCRIPTION
Fix redundant js reloads caused by https://github.com/calcit-lang/calcit_runner.rs/pull/89 .