### PR TITLE
refactoring to rpds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a8da9bc4c4053ee067669762bcaeea6e241841295a2b6c948312dad6ef4cc02"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,15 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "calcit_runner"
 version = "0.5.0-a20"
 dependencies = [
@@ -53,10 +53,10 @@ dependencies = [
  "ctrlc",
  "dirs",
  "hex 0.4.3",
- "im",
  "lazy_static",
  "libloading",
  "notify",
+ "rpds",
  "walkdir",
 ]
 
@@ -217,20 +217,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "inotify"
@@ -403,21 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpds"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054e417ded02a19ae192c8c89412eaec7d1c2cdd826aa412565761d86ca6315e"
+dependencies = [
+ "archery",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,20 +426,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e65d6a9f13cd78f361ea5a2cf53a45d67cdda421ba0316b9be101560f3d207"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -477,12 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,12 +463,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ cirru_edn = "0.2.3"
 cirru_parser = "0.1.10"
 clap = "2.33.3"
 dirs = "4.0.0"
-im = "15.0.0"
 lazy_static = "1.4.0"
 notify = "4.0.17"
 walkdir = "2"
 hex = "0.4.3"
+rpds = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.7.1"

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -103,7 +103,7 @@ fn main() -> Result<(), String> {
     calcit_runner::primes::BUILTIN_CLASSES_ENTRY,
     None,
     check_warnings,
-    &im::Vector::new(),
+    &rpds::Vector::new_sync(),
   )
   .map_err(|e| e.msg)?;
 
@@ -114,7 +114,7 @@ fn main() -> Result<(), String> {
   } else {
     let started_time = Instant::now();
 
-    let v = calcit_runner::run_program(init_fn, im::vector![]).map_err(|e| {
+    let v = calcit_runner::run_program(init_fn, rpds::vector_sync![]).map_err(|e| {
       for w in e.warnings {
         println!("{}", w);
       }
@@ -223,7 +223,7 @@ fn recall_program(content: &str, init_fn: &str, reload_fn: &str, settings: &Prog
   } else {
     // run from `reload_fn` after reload
     let started_time = Instant::now();
-    let v = calcit_runner::run_program(reload_fn, im::vector![]).map_err(|e| {
+    let v = calcit_runner::run_program(reload_fn, rpds::vector_sync![]).map_err(|e| {
       for w in e.warnings {
         println!("{}", w);
       }
@@ -267,7 +267,7 @@ fn run_codegen(init_fn: &str, reload_fn: &str, emit_path: &str, ir_mode: bool) -
   gen_stack::clear_stack();
 
   // preprocess to init
-  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &init_def, None, check_warnings, &im::Vector::new()) {
+  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &init_def, None, check_warnings, &rpds::Vector::new_sync()) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);
@@ -285,7 +285,7 @@ fn run_codegen(init_fn: &str, reload_fn: &str, emit_path: &str, ir_mode: bool) -
   }
 
   // preprocess to reload
-  match runner::preprocess::preprocess_ns_def(&reload_ns, &reload_def, &init_def, None, check_warnings, &im::Vector::new()) {
+  match runner::preprocess::preprocess_ns_def(&reload_ns, &reload_def, &init_def, None, check_warnings, &rpds::Vector::new_sync()) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -134,9 +134,9 @@ pub fn call_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackVec) -> Result<
       ys.to_owned(),
       Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
         if let Calcit::Fn(_, def_ns, _, def_scope, args, body) = &callback {
-          let mut real_args = im::vector![];
+          let mut real_args = rpds::vector_sync![];
           for p in ps {
-            real_args.push_back(edn_to_calcit(&p));
+            real_args.push_back_mut(edn_to_calcit(&p));
           }
           let r = runner::run_fn(&real_args, def_scope, args, body, def_ns, &copied_stack);
           match r {
@@ -218,9 +218,9 @@ pub fn blocking_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackVec) -> Res
     ys.to_owned(),
     Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
       if let Calcit::Fn(_, def_ns, _, def_scope, args, body) = &callback {
-        let mut real_args = im::vector![];
+        let mut real_args = rpds::vector_sync![];
         for p in ps {
-          real_args.push_back(edn_to_calcit(&p));
+          real_args.push_back_mut(edn_to_calcit(&p));
         }
         let r = runner::run_fn(&real_args, def_scope, args, body, def_ns, &copied_stack.clone());
         match r {
@@ -256,7 +256,7 @@ pub fn on_ctrl_c(xs: &CalcitItems, call_stack: &CallStackVec) -> Result<Calcit, 
     let copied_stack = Arc::new(call_stack.to_owned());
     ctrlc::set_handler(move || {
       if let Calcit::Fn(_name, def_ns, _, def_scope, args, body) = cb.as_ref() {
-        if let Err(e) = runner::run_fn(&im::vector![], def_scope, args, body, def_ns, &copied_stack) {
+        if let Err(e) = runner::run_fn(&rpds::vector_sync![], def_scope, args, body, def_ns, &copied_stack) {
           println!("error: {}", e);
         }
       }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -277,42 +277,42 @@ pub fn invoke_method(name: &str, invoke_args: &CalcitItems, call_stack: &CallSta
     Calcit::Number(..) => {
       // classed should already be preprocessed
       let code = gen_sym("&core-number-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Str(..) => {
       let code = gen_sym("&core-string-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Set(..) => {
       let code = gen_sym("&core-set-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::List(..) => {
       let code = gen_sym("&core-list-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Map(..) => {
       let code = gen_sym("&core-map-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Record(..) => {
       let code = gen_sym("&core-record-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Nil => {
       let code = gen_sym("&core-nil-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     Calcit::Fn(..) | Calcit::Proc(..) => {
       let code = gen_sym("&core-fn-class");
-      let class = runner::evaluate_expr(&code, &im::HashMap::new(), primes::CORE_NS, call_stack)?;
+      let class = runner::evaluate_expr(&code, &rpds::HashTrieMap::new_sync(), primes::CORE_NS, call_stack)?;
       (class, invoke_args[0].to_owned())
     }
     x => return Err(CalcitErr::use_msg_stack(format!("cannot decide a class from: {:?}", x), call_stack)),
@@ -321,14 +321,14 @@ pub fn invoke_method(name: &str, invoke_args: &CalcitItems, call_stack: &CallSta
     Calcit::Record(_, fields, values) => {
       match find_in_fields(fields, load_order_key(name)) {
         Some(idx) => {
-          let mut method_args: im::Vector<Calcit> = im::vector![];
-          method_args.push_back(value);
+          let mut method_args: rpds::VectorSync<Calcit> = rpds::vector_sync![];
+          method_args.push_back_mut(value);
           let mut at_first = true;
           for x in invoke_args {
             if at_first {
               at_first = false
             } else {
-              method_args.push_back(x.to_owned())
+              method_args.push_back_mut(x.to_owned())
             }
           }
 

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -152,9 +152,9 @@ pub fn turn_map(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   }
   match &xs[0] {
     Calcit::Record(_name, fields, values) => {
-      let mut ys: im::HashMap<Calcit, Calcit> = im::HashMap::new();
+      let mut ys: rpds::HashTrieMapSync<Calcit, Calcit> = rpds::HashTrieMap::new_sync();
       for idx in 0..fields.len() {
-        ys.insert(Calcit::Keyword(fields[idx].to_owned()), values[idx].to_owned());
+        ys.insert_mut(Calcit::Keyword(fields[idx].to_owned()), values[idx].to_owned());
       }
       Ok(Calcit::Map(ys))
     }

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -30,7 +30,7 @@ fn modify_ref(path: String, v: Calcit, call_stack: &CallStackVec) -> Result<(), 
   for f in listeners.values() {
     match f {
       Calcit::Fn(_, def_ns, _, def_scope, args, body) => {
-        let values = im::vector![v.to_owned(), prev.to_owned()];
+        let values = rpds::vector_sync![v.to_owned(), prev.to_owned()];
         runner::run_fn(&values, def_scope, args, body, def_ns, call_stack)?;
       }
       a => {

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -1,9 +1,9 @@
 use crate::primes::{Calcit, CalcitErr, CalcitItems};
 
 pub fn new_set(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
-  let mut ys = im::HashSet::new();
+  let mut ys = rpds::HashTrieSet::new_sync();
   for x in xs {
-    ys.insert(x.to_owned());
+    ys.insert_mut(x.to_owned());
   }
   Ok(Calcit::Set(ys))
 }
@@ -12,7 +12,7 @@ pub fn call_include(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Set(xs)), Some(a)) => {
       let mut ys = xs.to_owned();
-      ys.insert(a.to_owned());
+      ys.insert_mut(a.to_owned());
       Ok(Calcit::Set(ys))
     }
     (Some(a), _) => CalcitErr::err_str(format!("&include expect a set, but got: {}", a)),
@@ -24,7 +24,7 @@ pub fn call_exclude(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Set(xs)), Some(a)) => {
       let mut ys = xs.to_owned();
-      ys.remove(a);
+      ys.remove_mut(a);
       Ok(Calcit::Set(ys))
     }
     (Some(a), _) => CalcitErr::err_str(format!("&exclude expect a set, but got: {}", a)),
@@ -34,11 +34,11 @@ pub fn call_exclude(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 pub fn call_difference(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => {
-      // im::HashSet::difference has different semantics
+      // rpds::HashTrieSetSync::difference has different semantics
       // https://docs.rs/im/12.2.0/im/struct.HashSet.html#method.difference
       let mut ys = a.to_owned();
       for item in b {
-        ys.remove(item);
+        ys.remove_mut(item);
       }
       Ok(Calcit::Set(ys))
     }
@@ -48,14 +48,28 @@ pub fn call_difference(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 }
 pub fn call_union(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => Ok(Calcit::Set(a.to_owned().union(b.to_owned()))),
+    (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => {
+      let mut c = a.to_owned();
+      for x in b.iter() {
+        c.insert_mut(x.to_owned());
+      }
+      Ok(Calcit::Set(c))
+    }
     (Some(a), Some(b)) => CalcitErr::err_str(format!("&union expected 2 sets: {} {}", a, b)),
     (a, b) => CalcitErr::err_str(format!("&union expected 2 arguments: {:?} {:?}", a, b)),
   }
 }
 pub fn call_intersection(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
-    (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => Ok(Calcit::Set(a.to_owned().intersection(b.to_owned()))),
+    (Some(Calcit::Set(a)), Some(Calcit::Set(b))) => {
+      let mut c: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
+      for x in a.iter() {
+        if b.contains(x) {
+          c.insert_mut(x.to_owned())
+        }
+      }
+      Ok(Calcit::Set(c))
+    }
     (Some(a), Some(b)) => CalcitErr::err_str(format!("&set:intersection expected 2 sets: {} {}", a, b)),
     (a, b) => CalcitErr::err_str(format!("&set:intersection expected 2 arguments: {:?} {:?}", a, b)),
   }
@@ -65,9 +79,9 @@ pub fn call_intersection(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 pub fn set_to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Set(xs)) => {
-      let mut ys: CalcitItems = im::vector![];
+      let mut ys: CalcitItems = rpds::vector_sync![];
       for x in xs {
-        ys.push_back(x.to_owned());
+        ys.push_back_mut(x.to_owned());
       }
       Ok(Calcit::List(ys))
     }
@@ -78,7 +92,7 @@ pub fn set_to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 
 pub fn count(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
-    Some(Calcit::Set(ys)) => Ok(Calcit::Number(ys.len() as f64)),
+    Some(Calcit::Set(ys)) => Ok(Calcit::Number(ys.size() as f64)),
     Some(a) => CalcitErr::err_str(format!("set count expected a set, got: {}", a)),
     None => CalcitErr::err_str("set count expected 1 argument"),
   }
@@ -118,7 +132,7 @@ pub fn rest(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     Some(Calcit::Set(ys)) => match ys.iter().next() {
       Some(y0) => {
         let mut zs = ys.to_owned();
-        zs.remove(y0);
+        zs.remove_mut(y0);
         Ok(Calcit::Set(zs))
       }
       None => Ok(Calcit::Nil),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -60,10 +60,10 @@ pub fn split(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Str(s)), Some(Calcit::Str(pattern))) => {
       let pieces = s.split(pattern);
-      let mut ys: CalcitItems = im::vector![];
+      let mut ys: CalcitItems = rpds::vector_sync![];
       for p in pieces {
         if !p.is_empty() {
-          ys.push_back(Calcit::Str(p.to_owned()));
+          ys.push_back_mut(Calcit::Str(p.to_owned()));
         }
       }
       Ok(Calcit::List(ys))
@@ -98,9 +98,9 @@ pub fn split_lines(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Str(s)) => {
       let lines = s.split('\n');
-      let mut ys = im::vector![];
+      let mut ys = rpds::vector_sync![];
       for line in lines {
-        ys.push_back(Calcit::Str(line.to_owned()));
+        ys.push_back_mut(Calcit::Str(line.to_owned()));
       }
       Ok(Calcit::List(ys))
     }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -9,6 +9,7 @@ use crate::builtins;
 use crate::call_stack::CallStackVec;
 use crate::primes::{gen_core_id, Calcit, CalcitErr, CalcitItems, CalcitScope};
 use crate::runner;
+use crate::util::{skip, slice};
 
 pub fn defn(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str) -> Result<Calcit, CalcitErr> {
   match (expr.get(0), expr.get(1)) {
@@ -18,7 +19,7 @@ pub fn defn(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str) -> Result<Ca
       gen_core_id(),
       scope.to_owned(),
       Box::new(xs.to_owned()),
-      Box::new(expr.skip(2)),
+      Box::new(skip(expr, 2)),
     )),
     (Some(a), Some(b)) => CalcitErr::err_str(format!("invalid args type for defn: {} , {}", a, b)),
     _ => CalcitErr::err_str("inefficient arguments for defn"),
@@ -32,7 +33,7 @@ pub fn defmacro(expr: &CalcitItems, _scope: &CalcitScope, def_ns: &str) -> Resul
       def_ns.to_owned(),
       gen_core_id(),
       Box::new(xs.to_owned()),
-      Box::new(expr.skip(2)),
+      Box::new(skip(expr, 2)),
     )),
     (Some(a), Some(b)) => CalcitErr::err_str(format!("invalid structure for defmacro: {} {}", a, b)),
     _ => CalcitErr::err_str(format!("invalid structure for defmacro: {}", Calcit::List(expr.to_owned()))),
@@ -76,17 +77,17 @@ pub fn eval(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_stack: 
 
 pub fn syntax_let(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackVec) -> Result<Calcit, CalcitErr> {
   match expr.get(0) {
-    Some(Calcit::Nil) => runner::evaluate_lines(&expr.skip(1), scope, file_ns, call_stack),
+    Some(Calcit::Nil) => runner::evaluate_lines(&skip(expr, 1), scope, file_ns, call_stack),
     Some(Calcit::List(xs)) if xs.len() == 2 => {
       let mut body_scope = scope.to_owned();
       match (&xs[0], &xs[1]) {
         (Calcit::Symbol(s, ..), ys) => {
           let value = runner::evaluate_expr(ys, scope, file_ns, call_stack)?;
-          body_scope.insert(s.to_owned(), value);
+          body_scope.insert_mut(s.to_owned(), value);
         }
         (a, _) => return CalcitErr::err_str(format!("invalid binding name: {}", a)),
       }
-      runner::evaluate_lines(&expr.skip(1), &body_scope, file_ns, call_stack)
+      runner::evaluate_lines(&skip(expr, 1), &body_scope, file_ns, call_stack)
     }
     Some(Calcit::List(xs)) => CalcitErr::err_str(format!("invalid length: {:?}", xs)),
     Some(_) => CalcitErr::err_str(format!("invalid node for &let: {:?}", expr)),
@@ -134,13 +135,13 @@ fn replace_code(c: &Calcit, scope: &CalcitScope, file_ns: &str, call_stack: &Cal
         }
       }
       (_, _) => {
-        let mut ret = im::vector![];
+        let mut ret = rpds::vector_sync![];
         for y in ys {
           match replace_code(y, scope, file_ns, call_stack)? {
-            SpanResult::Single(z) => ret.push_back(z),
+            SpanResult::Single(z) => ret.push_back_mut(z),
             SpanResult::Range(pieces) => {
-              for piece in pieces {
-                ret.push_back(piece);
+              for piece in pieces.iter() {
+                ret.push_back_mut(piece.to_owned());
               }
             }
           }
@@ -179,9 +180,8 @@ pub fn macroexpand(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_
         let v = runner::evaluate_expr(&xs[0], scope, file_ns, call_stack)?;
         match v {
           Calcit::Macro(_, def_ns, _, args, body) => {
-            let mut xs_cloned = xs;
             // mutable operation
-            let mut rest_nodes = xs_cloned.slice(1..);
+            let mut rest_nodes = slice(&xs, 1, xs.len());
             // println!("macro: {:?} ... {:?}", args, rest_nodes);
             // keep expanding until return value is not a recur
             loop {
@@ -217,8 +217,7 @@ pub fn macroexpand_1(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, cal
         let v = runner::evaluate_expr(&xs[0], scope, file_ns, call_stack)?;
         match v {
           Calcit::Macro(_, def_ns, _, args, body) => {
-            let mut xs_cloned = xs;
-            let body_scope = runner::bind_args(&args, &xs_cloned.slice(1..), scope, call_stack)?;
+            let body_scope = runner::bind_args(&args, &slice(&xs, 1, xs.len()), scope, call_stack)?;
             runner::evaluate_lines(&body, &body_scope, &def_ns, call_stack)
           }
           _ => Ok(quoted_code),
@@ -243,9 +242,8 @@ pub fn macroexpand_all(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, c
         let v = runner::evaluate_expr(&xs[0], scope, file_ns, call_stack)?;
         match v {
           Calcit::Macro(_, def_ns, _, args, body) => {
-            let mut xs_cloned = xs;
             // mutable operation
-            let mut rest_nodes = xs_cloned.slice(1..);
+            let mut rest_nodes = slice(&xs, 1, xs.len());
             let check_warnings: &RefCell<Vec<String>> = &RefCell::new(vec![]);
             // println!("macro: {:?} ... {:?}", args, rest_nodes);
             // keep expanding until return value is not a recur
@@ -303,10 +301,10 @@ pub fn call_try(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_sta
         let err_data = Calcit::Str(failure.msg.to_owned());
         match f {
           Calcit::Fn(_, def_ns, _, def_scope, args, body) => {
-            let values = im::vector![err_data];
+            let values = rpds::vector_sync![err_data];
             runner::run_fn(&values, &def_scope, &args, &body, &def_ns, call_stack)
           }
-          Calcit::Proc(proc) => builtins::handle_proc(&proc, &im::vector![err_data], call_stack),
+          Calcit::Proc(proc) => builtins::handle_proc(&proc, &rpds::vector_sync![err_data], call_stack),
           a => CalcitErr::err_str(format!("try expected a function handler, got: {}", a)),
         }
       }

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -23,14 +23,14 @@ pub enum StackKind {
   Codegen, // track preprocessing
 }
 
-pub type CallStackVec = im::Vector<CalcitStack>;
+pub type CallStackVec = rpds::VectorSync<CalcitStack>;
 
 // TODO impl fmt
 
 /// create new entry to the tree
 pub fn extend_call_stack(stack: &CallStackVec, ns: &str, def: &str, kind: StackKind, code: Calcit, args: &CalcitItems) -> CallStackVec {
   let mut s2 = stack.to_owned();
-  s2.push_back(CalcitStack {
+  s2.push_back_mut(CalcitStack {
     ns: ns.to_owned(),
     def: def.to_owned(),
     code,

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -31,23 +31,27 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str) -> Result<Calcit, String>
           Ok(n) => Ok(Calcit::Number(n as f64)),
           Err(e) => Err(format!("failed to parse hex: {} => {:?}", s, e)),
         },
-        '\'' if s.len() > 1 => Ok(Calcit::List(im::vector![
-          Calcit::Symbol(String::from("quote"), ns.to_owned(), def.to_owned(), None),
-          Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None),
-        ])),
+        '\'' if s.len() > 1 => Ok(Calcit::List(
+          rpds::vector_sync![]
+            .push_back(Calcit::Symbol(String::from("quote"), ns.to_owned(), def.to_owned(), None))
+            .push_back(Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None)),
+        )),
         // TODO also detect simple variables
-        '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(im::vector![
-          Calcit::Symbol(String::from("~@"), ns.to_owned(), def.to_owned(), None),
-          Calcit::Symbol(String::from(&s[2..]), ns.to_owned(), def.to_owned(), None),
-        ])),
-        '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(im::vector![
-          Calcit::Symbol(String::from("~"), ns.to_owned(), def.to_owned(), None),
-          Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None),
-        ])),
-        '@' => Ok(Calcit::List(im::vector![
-          Calcit::Symbol(String::from("deref"), ns.to_owned(), def.to_owned(), None),
-          Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None),
-        ])),
+        '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(
+          rpds::vector_sync![]
+            .push_back(Calcit::Symbol(String::from("~@"), ns.to_owned(), def.to_owned(), None))
+            .push_back(Calcit::Symbol(String::from(&s[2..]), ns.to_owned(), def.to_owned(), None)),
+        )),
+        '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(
+          rpds::vector_sync![]
+            .push_back(Calcit::Symbol(String::from("~"), ns.to_owned(), def.to_owned(), None))
+            .push_back(Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None)),
+        )),
+        '@' => Ok(Calcit::List(
+          rpds::vector_sync![]
+            .push_back(Calcit::Symbol(String::from("deref"), ns.to_owned(), def.to_owned(), None))
+            .push_back(Calcit::Symbol(String::from(&s[1..]), ns.to_owned(), def.to_owned(), None)),
+        )),
         // TODO future work of reader literal expanding
         _ => {
           if let Ok(f) = s.parse::<f64>() {
@@ -59,12 +63,12 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str) -> Result<Calcit, String>
       },
     },
     Cirru::List(ys) => {
-      let mut zs: CalcitItems = im::Vector::new();
+      let mut zs: CalcitItems = rpds::VectorSync::new_sync();
       for y in ys {
         match code_to_calcit(y, ns, def) {
           Ok(v) => {
             if !is_comment(&v) {
-              zs.push_back(v.to_owned())
+              zs.push_back_mut(v.to_owned())
             } else {
             }
           }
@@ -81,9 +85,9 @@ pub fn cirru_to_calcit(xs: &Cirru) -> Calcit {
   match xs {
     Cirru::Leaf(s) => Calcit::Str(s.to_owned()),
     Cirru::List(ys) => {
-      let mut zs: CalcitItems = im::vector![];
+      let mut zs: CalcitItems = rpds::vector_sync![];
       for y in ys {
-        zs.push_back(cirru_to_calcit(y))
+        zs.push_back_mut(cirru_to_calcit(y))
       }
       Calcit::List(zs)
     }

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -29,7 +29,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
       Ok(Edn::Set(ys))
     }
     Calcit::Map(xs) => {
-      let mut ys: HashMap<Edn, Edn> = HashMap::with_capacity(xs.len());
+      let mut ys: HashMap<Edn, Edn> = HashMap::with_capacity(xs.size());
       for (k, x) in xs {
         ys.insert(calcit_to_edn(k)?, calcit_to_edn(x)?);
       }
@@ -96,23 +96,23 @@ pub fn edn_to_calcit(x: &Edn) -> Calcit {
     ),
     Edn::Tuple(pair) => Calcit::Tuple(Box::new(edn_to_calcit(&pair.0)), Box::new(edn_to_calcit(&pair.1))),
     Edn::List(xs) => {
-      let mut ys: primes::CalcitItems = im::vector![];
+      let mut ys: primes::CalcitItems = rpds::vector_sync![];
       for x in xs {
-        ys.push_back(edn_to_calcit(x))
+        ys.push_back_mut(edn_to_calcit(x))
       }
       Calcit::List(ys)
     }
     Edn::Set(xs) => {
-      let mut ys: im::HashSet<Calcit> = im::HashSet::new();
+      let mut ys: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for x in xs {
-        ys.insert(edn_to_calcit(x));
+        ys.insert_mut(edn_to_calcit(x));
       }
       Calcit::Set(ys)
     }
     Edn::Map(xs) => {
-      let mut ys: im::HashMap<Calcit, Calcit> = im::HashMap::new();
+      let mut ys: rpds::HashTrieMapSync<Calcit, Calcit> = rpds::HashTrieMap::new_sync();
       for (k, v) in xs {
-        ys.insert(edn_to_calcit(k), edn_to_calcit(v));
+        ys.insert_mut(edn_to_calcit(k), edn_to_calcit(v));
       }
       Calcit::Map(ys)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub fn run_program(init_fn: &str, params: CalcitItems) -> Result<Calcit, CalcitE
   let check_warnings: &RefCell<Vec<String>> = &RefCell::new(vec![]);
 
   // preprocess to init
-  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &init_def, None, check_warnings, &im::Vector::new()) {
+  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &init_def, None, check_warnings, &rpds::VectorSync::new_sync()) {
     Ok(_) => (),
     Err(failure) => {
       println!("\nfailed preprocessing, {}", failure);
@@ -48,14 +48,14 @@ pub fn run_program(init_fn: &str, params: CalcitItems) -> Result<Calcit, CalcitE
     return Err(CalcitErr {
       msg: format!("Found {} warnings, runner blocked", warnings.len()),
       warnings: warnings.to_owned(),
-      stack: im::vector![],
+      stack: rpds::vector_sync![],
     });
   }
   match program::lookup_evaled_def(&init_ns, &init_def) {
     None => CalcitErr::err_str(format!("entry not initialized: {}/{}", init_ns, init_def)),
     Some(entry) => match entry {
       Calcit::Fn(_, f_ns, _, def_scope, args, body) => {
-        let result = runner::run_fn(&params, &def_scope, &args, &body, &f_ns, &im::Vector::new());
+        let result = runner::run_fn(&params, &def_scope, &args, &body, &f_ns, &rpds::VectorSync::new_sync());
         match result {
           Ok(v) => Ok(v),
           Err(failure) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,2 +1,58 @@
 pub mod number;
 pub mod string;
+
+use std::cmp::Ordering;
+
+use crate::primes::Calcit;
+
+pub fn skip(xs: &rpds::VectorSync<Calcit>, skipped: usize) -> rpds::VectorSync<Calcit> {
+  let mut ys: rpds::VectorSync<Calcit> = rpds::Vector::new_sync();
+  for (idx, x) in xs.iter().enumerate() {
+    if idx >= skipped {
+      ys.push_back_mut(x.to_owned());
+    }
+  }
+  ys
+}
+
+pub fn slice(xs: &rpds::VectorSync<Calcit>, from: usize, to: usize) -> rpds::VectorSync<Calcit> {
+  let mut ys: rpds::VectorSync<Calcit> = rpds::Vector::new_sync();
+  for (idx, x) in xs.iter().enumerate() {
+    if idx >= from && idx < to {
+      ys.push_back_mut(x.to_owned());
+    }
+  }
+  ys
+}
+
+pub fn contains(xs: &rpds::VectorSync<Calcit>, y: &Calcit) -> bool {
+  for x in xs.iter() {
+    if x == y {
+      return true;
+    }
+  }
+  false
+}
+
+pub fn insert(xs: &rpds::VectorSync<Calcit>, pos: usize, y: Calcit) -> rpds::VectorSync<Calcit> {
+  let mut ys: rpds::VectorSync<Calcit> = rpds::Vector::new_sync();
+
+  match pos.cmp(&xs.len()) {
+    Ordering::Less => {
+      for (idx, x) in xs.iter().enumerate() {
+        if idx == pos {
+          ys.push_back_mut(y.to_owned());
+        }
+        ys.push_back_mut(x.to_owned());
+      }
+    }
+    Ordering::Equal => {
+      ys = xs.to_owned();
+      ys.push_back_mut(y.to_owned());
+    }
+    Ordering::Greater => {
+      println!("[Error] TODO error")
+    }
+  }
+  ys
+}


### PR DESCRIPTION
migrating from https://docs.rs/im/15.0.0/im/ to https://docs.rs/rpds/0.10.0/rpds/ .

rpds has better maintenance. however, rpds has fewer methods implemented compared to im, so I have to add some very naive code related to list operations.

luckily, it becomes a litter faster after refactoring.

binary size went from 6128 to 5600. (not configuring features yet)