### PR TITLE
Refactor to reduce memory occupation in js, but with regress on performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit_runner"
-version = "0.5.0-a23"
+version = "0.5.0-a24"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit_runner"
-version = "0.5.0-a23"
+version = "0.5.0-a24"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.5.0-a23",
+  "version": "0.5.0-a24",
   "main": "./lib/calcit.procs.js",
   "devDependencies": {
     "@types/node": "^16.10.5",

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -174,7 +174,7 @@ fn quote_to_js(xs: &Calcit, var_prefix: &str, keywords: &RefCell<Vec<EdnKwd>>) -
         }
         chunk.push_str(&quote_to_js(y, var_prefix, keywords)?);
       }
-      Ok(format!("new {}CalcitList([{}])", var_prefix, chunk))
+      Ok(format!("new {}CalcitSliceList([{}])", var_prefix, chunk))
     }
     Calcit::Keyword(s) => {
       let mut kwds = keywords.borrow_mut();

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -100,7 +100,7 @@ pub fn tmpl_tail_recursion(
 pub fn tmpl_import_procs(name: String) -> String {
   format!(
     "
-import {{kwd, arrayToList, listToArray, CalcitList, CalcitSymbol, CalcitRecur}} from {};
+import {{kwd, arrayToList, listToArray, CalcitSliceList, CalcitSymbol, CalcitRecur}} from {};
 import * as $calcit_procs from {};
 export * from {};
 ",

--- a/ts-src/calcit-data.ts
+++ b/ts-src/calcit-data.ts
@@ -3,7 +3,7 @@ import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { overwriteMapComparator } from "./js-map";
 
 import { CalcitRecord, fieldsEqual } from "./js-record";
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 
 import { CalcitValue } from "./js-primes";
 import { CalcitList, CalcitSliceList } from "./js-list";
@@ -69,7 +69,7 @@ export let isNestedCalcitData = (x: CalcitValue): boolean => {
   if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return x.len() > 0;
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return x.len() > 0;
   }
   if (x instanceof CalcitRecord) {
@@ -85,7 +85,7 @@ export let tipNestedCalcitData = (x: CalcitValue): string => {
   if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return "'[]...";
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return "'{}...";
   }
   if (x instanceof CalcitRecord) {
@@ -268,7 +268,7 @@ let hashFunction = (x: CalcitValue): Hash => {
     x.cachedHash = base;
     return base;
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     let base = defaultHash_map;
     for (let [k, v] of x.pairs()) {
       base = mergeValueHash(base, hashFunction(k));
@@ -334,7 +334,7 @@ export let toString = (x: CalcitValue, escaped: boolean): string => {
   if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return x.toString();
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return x.toString();
   }
   if (x instanceof CalcitSet) {
@@ -389,7 +389,7 @@ export let to_js_data = (x: CalcitValue, addColon: boolean = false): any => {
     }
     return result;
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     let result: Record<string, CalcitValue> = {};
     for (let [k, v] of x.pairs()) {
       var key = to_js_data(k, addColon);
@@ -426,7 +426,7 @@ export let _$n_map_$o_get = function (xs: CalcitValue, k: CalcitValue) {
     throw new Error("map &get takes 2 arguments");
   }
 
-  if (xs instanceof CalcitMap) return xs.get(k);
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) return xs.get(k);
 
   throw new Error("Does not support `&get` on this type");
 };
@@ -491,8 +491,8 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
     }
     return false;
   }
-  if (x instanceof CalcitMap) {
-    if (y instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
+    if (y instanceof CalcitMap || y instanceof CalcitSliceMap) {
       if (x.len() !== y.len()) {
         return false;
       }

--- a/ts-src/calcit-data.ts
+++ b/ts-src/calcit-data.ts
@@ -6,7 +6,7 @@ import { CalcitRecord, fieldsEqual } from "./js-record";
 import { CalcitMap } from "./js-map";
 
 import { CalcitValue } from "./js-primes";
-import { CalcitList } from "./js-list";
+import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitSet, overwriteSetComparator } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
 
@@ -66,7 +66,7 @@ export class CalcitRecur {
 }
 
 export let isNestedCalcitData = (x: CalcitValue): boolean => {
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return x.len() > 0;
   }
   if (x instanceof CalcitMap) {
@@ -82,7 +82,7 @@ export let isNestedCalcitData = (x: CalcitValue): boolean => {
 };
 
 export let tipNestedCalcitData = (x: CalcitValue): string => {
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return "'[]...";
   }
   if (x instanceof CalcitMap) {
@@ -260,7 +260,7 @@ let hashFunction = (x: CalcitValue): Hash => {
     }
     return base;
   }
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     let base = defaultHash_list;
     for (let item of x.items()) {
       base = mergeValueHash(base, hashFunction(item));
@@ -331,7 +331,7 @@ export let toString = (x: CalcitValue, escaped: boolean): string => {
   if (x instanceof CalcitKeyword) {
     return x.toString();
   }
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return x.toString();
   }
   if (x instanceof CalcitMap) {
@@ -382,7 +382,7 @@ export let to_js_data = (x: CalcitValue, addColon: boolean = false): any => {
     }
     return Symbol(x.value);
   }
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     var result: any[] = [];
     for (let item of x.items()) {
       result.push(to_js_data(item, addColon));
@@ -474,8 +474,8 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
     }
     return false;
   }
-  if (x instanceof CalcitList) {
-    if (y instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
+    if (y instanceof CalcitList || y instanceof CalcitSliceList) {
       if (x.len() !== y.len()) {
         return false;
       }

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -21,7 +21,7 @@ export * from "./custom-formatter";
 export * from "./js-cirru";
 
 import { CalcitList, CalcitSliceList, foldl } from "./js-list";
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 import { CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
 import { to_calcit_data, extract_cirru_edn } from "./js-cirru";
@@ -41,7 +41,7 @@ export let type_of = (x: any): CalcitKeyword => {
   if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return kwd("list");
   }
-  if (x instanceof CalcitMap) {
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return kwd("map");
   }
   if (x == null) {
@@ -94,7 +94,7 @@ export function _$n_str_$o_count(x: CalcitValue): number {
   throw new Error(`expected a string ${x}`);
 }
 export function _$n_map_$o_count(x: CalcitValue): number {
-  if (x instanceof CalcitMap) return x.len();
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return x.len();
 
   throw new Error(`expected a map ${x}`);
 }
@@ -117,11 +117,11 @@ export let _SQUO_ = (...xs: CalcitValue[]): CalcitSliceList => {
   return new CalcitSliceList(xs);
 };
 
-export let _$n__$M_ = (...xs: CalcitValue[]): CalcitMap => {
+export let _$n__$M_ = (...xs: CalcitValue[]): CalcitSliceMap => {
   if (xs.length % 2 !== 0) {
     throw new Error("&map expects even number of arguments");
   }
-  return new CalcitMap(xs);
+  return new CalcitSliceMap(xs);
 };
 
 export let defatom = (path: string, x: CalcitValue): CalcitValue => {
@@ -185,7 +185,7 @@ export let _$n_list_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean
 };
 
 export let _$n_map_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
-  if (xs instanceof CalcitMap) return xs.contains(x);
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) return xs.contains(x);
 
   throw new Error("map `contains?` expected a map");
 };
@@ -222,7 +222,7 @@ export let _$n_list_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean
 };
 
 export let _$n_map_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     for (let [k, v] of xs.pairs()) {
       if (_$n__$e_(v, x)) {
         return true;
@@ -306,7 +306,7 @@ export let _$n_map_$o_assoc = function (xs: CalcitValue, ...args: CalcitValue[])
   if (arguments.length < 3) throw new Error("assoc takes at least 3 arguments");
   if (args.length % 2 !== 0) throw new Error("assoc expected odd arguments");
 
-  if (xs instanceof CalcitMap) return xs.assoc(...args);
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) return xs.assoc(...args);
 
   throw new Error("map `assoc` expected a map");
 };
@@ -360,7 +360,7 @@ export let _$n_list_$o_dissoc = function (xs: CalcitValue | CalcitSliceList, k: 
 export let _$n_map_$o_dissoc = function (xs: CalcitValue, ...args: CalcitValue[]) {
   if (args.length < 1) throw new Error("dissoc takes at least 2 arguments");
 
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     return xs.dissoc(...args);
   }
 
@@ -428,7 +428,7 @@ export function _$n_str_$o_empty_$q_(xs: CalcitValue): boolean {
   throw new Error(`expected a string ${xs}`);
 }
 export function _$n_map_$o_empty_$q_(xs: CalcitValue): boolean {
-  if (xs instanceof CalcitMap) return xs.isEmpty();
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) return xs.isEmpty();
 
   throw new Error(`expected a list ${xs}`);
 }
@@ -455,7 +455,7 @@ export let _$n_str_$o_first = (xs: CalcitValue): CalcitValue => {
   throw new Error("Expected a string");
 };
 export let _$n_map_$o_first = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     // TODO order may not be stable enough
     let ys = xs.pairs();
     if (ys.length > 0) {
@@ -511,12 +511,12 @@ export let _$n_set_$o_rest = (xs: CalcitValue): CalcitValue => {
   throw new Error("Expect a set");
 };
 export let _$n_map_$o_rest = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     if (xs.len() > 0) {
       let k0 = xs.pairs()[0][0];
       return xs.dissoc(k0);
     } else {
-      return new CalcitMap(initTernaryTreeMap<CalcitValue, CalcitValue>([]));
+      return new CalcitSliceMap([]);
     }
   }
   console.error(xs);
@@ -692,22 +692,22 @@ export let floor = (n: number): number => {
   return Math.floor(n);
 };
 
-export let _$n_merge = (a: CalcitValue, b: CalcitMap): CalcitValue => {
+export let _$n_merge = (a: CalcitValue, b: CalcitMap | CalcitSliceMap): CalcitValue => {
   if (a == null) {
     return b;
   }
   if (b == null) {
     return a;
   }
-  if (a instanceof CalcitMap) {
-    if (b instanceof CalcitMap) {
+  if (a instanceof CalcitMap || a instanceof CalcitSliceMap) {
+    if (b instanceof CalcitMap || b instanceof CalcitSliceMap) {
       return a.merge(b);
     } else {
       throw new Error("Expected an argument of map");
     }
   }
   if (a instanceof CalcitRecord) {
-    if (b instanceof CalcitMap) {
+    if (b instanceof CalcitMap || b instanceof CalcitSliceMap) {
       let values = [];
       for (let item of a.values) {
         values.push(item);
@@ -732,17 +732,17 @@ export let _$n_merge = (a: CalcitValue, b: CalcitMap): CalcitValue => {
   throw new Error("Expected map or record");
 };
 
-export let _$n_merge_non_nil = (a: CalcitMap, b: CalcitMap): CalcitMap => {
+export let _$n_merge_non_nil = (a: CalcitMap | CalcitSliceMap, b: CalcitMap | CalcitSliceMap): CalcitMap | CalcitSliceMap => {
   if (a == null) {
     return b;
   }
   if (b == null) {
     return a;
   }
-  if (!(a instanceof CalcitMap)) {
+  if (!(a instanceof CalcitMap || a instanceof CalcitSliceMap)) {
     throw new Error("Expected map");
   }
-  if (!(b instanceof CalcitMap)) {
+  if (!(b instanceof CalcitMap || b instanceof CalcitSliceMap)) {
     throw new Error("Expected map");
   }
 
@@ -750,7 +750,7 @@ export let _$n_merge_non_nil = (a: CalcitMap, b: CalcitMap): CalcitMap => {
 };
 
 export let to_pairs = (xs: CalcitValue): CalcitValue | CalcitSliceList => {
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     let result: Array<CalcitSliceList> = [];
     for (let [k, v] of xs.pairs()) {
       result.push(new CalcitSliceList([k, v]));
@@ -1077,7 +1077,7 @@ export let keyword_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitKeyword;
 };
 export let map_$q_ = (x: CalcitValue): boolean => {
-  return x instanceof CalcitMap;
+  return x instanceof CalcitMap || x instanceof CalcitSliceMap;
 };
 export let list_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitList || x instanceof CalcitSliceList;
@@ -1247,7 +1247,7 @@ export function invoke_method(p: string) {
       klass = calcit_builtin_classes.list;
     } else if (obj instanceof CalcitRecord) {
       klass = calcit_builtin_classes.record;
-    } else if (obj instanceof CalcitMap) {
+    } else if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
       klass = calcit_builtin_classes.map;
     } else {
       if ((obj as any)[p] == null) {
@@ -1269,7 +1269,7 @@ export function invoke_method(p: string) {
 }
 
 export let _$n_map_$o_to_list = (m: CalcitValue): CalcitSliceList => {
-  if (m instanceof CalcitMap) {
+  if (m instanceof CalcitMap || m instanceof CalcitSliceMap) {
     let ys = [];
     for (let pair of m.pairs()) {
       ys.push(new CalcitSliceList(pair));
@@ -1311,7 +1311,7 @@ let typeAsInt = (x: CalcitValue): number => {
   if (x instanceof CalcitRecur) return PseudoTypeIndex.recur;
   if (x instanceof CalcitList || x instanceof CalcitSliceList) return PseudoTypeIndex.list;
   if (x instanceof CalcitSet) return PseudoTypeIndex.set;
-  if (x instanceof CalcitMap) return PseudoTypeIndex.map;
+  if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return PseudoTypeIndex.map;
   if (x instanceof CalcitRecord) return PseudoTypeIndex.record;
   // proc, fn, macro, syntax, not distinguished
   if (t === "function") return PseudoTypeIndex.fn;
@@ -1364,7 +1364,7 @@ export let _$n_compare = (a: CalcitValue, b: CalcitValue): number => {
 };
 
 export let _$n_map_$o_diff_new = (a: CalcitValue, b: CalcitValue): CalcitMap => {
-  if (a instanceof CalcitMap && b instanceof CalcitMap) {
+  if ((a instanceof CalcitMap || a instanceof CalcitSliceMap) && (b instanceof CalcitMap || b instanceof CalcitSliceMap)) {
     return a.diffNew(b);
   } else {
     throw new Error("expected 2 maps");
@@ -1372,7 +1372,7 @@ export let _$n_map_$o_diff_new = (a: CalcitValue, b: CalcitValue): CalcitMap => 
 };
 
 export let _$n_map_$o_diff_keys = (a: CalcitValue, b: CalcitValue): CalcitSet => {
-  if (a instanceof CalcitMap && b instanceof CalcitMap) {
+  if ((a instanceof CalcitMap || a instanceof CalcitSliceMap) && (b instanceof CalcitMap || b instanceof CalcitSliceMap)) {
     return a.diffKeys(b);
   } else {
     throw new Error("expected 2 maps");
@@ -1380,7 +1380,7 @@ export let _$n_map_$o_diff_keys = (a: CalcitValue, b: CalcitValue): CalcitSet =>
 };
 
 export let _$n_map_$o_common_keys = (a: CalcitValue, b: CalcitValue): CalcitSet => {
-  if (a instanceof CalcitMap && b instanceof CalcitMap) {
+  if ((a instanceof CalcitMap || a instanceof CalcitSliceMap) && (b instanceof CalcitMap || b instanceof CalcitSliceMap)) {
     return a.commonKeys(b);
   } else {
     throw new Error("expected 2 maps");

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -20,7 +20,7 @@ export * from "./js-tuple";
 export * from "./custom-formatter";
 export * from "./js-cirru";
 
-import { CalcitList, foldl } from "./js-list";
+import { CalcitList, CalcitSliceList, foldl } from "./js-list";
 import { CalcitMap } from "./js-map";
 import { CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
@@ -38,7 +38,7 @@ export let type_of = (x: any): CalcitKeyword => {
   if (x instanceof CalcitKeyword) {
     return kwd("keyword");
   }
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     return kwd("list");
   }
   if (x instanceof CalcitMap) {
@@ -84,7 +84,7 @@ export let print = (...xs: CalcitValue[]): void => {
 };
 
 export function _$n_list_$o_count(x: CalcitValue): number {
-  if (x instanceof CalcitList) return x.len();
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) return x.len();
 
   throw new Error(`expected a list ${x}`);
 }
@@ -109,12 +109,12 @@ export function _$n_set_$o_count(x: CalcitValue): number {
   throw new Error(`expected a set ${x}`);
 }
 
-export let _$L_ = (...xs: CalcitValue[]): CalcitList => {
-  return new CalcitList(xs);
+export let _$L_ = (...xs: CalcitValue[]): CalcitSliceList => {
+  return new CalcitSliceList(xs);
 };
 // single quote as alias for list
-export let _SQUO_ = (...xs: CalcitValue[]): CalcitList => {
-  return new CalcitList(xs);
+export let _SQUO_ = (...xs: CalcitValue[]): CalcitSliceList => {
+  return new CalcitSliceList(xs);
 };
 
 export let _$n__$M_ = (...xs: CalcitValue[]): CalcitMap => {
@@ -170,7 +170,7 @@ export let _$n_str_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean 
 };
 
 export let _$n_list_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (typeof x != "number") {
       throw new Error("Expected number index for detecting");
     }
@@ -208,7 +208,7 @@ export let _$n_str_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean 
 };
 
 export let _$n_list_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     let size = xs.len();
     for (let v of xs.items()) {
       if (_$n__$e_(v, x)) {
@@ -255,7 +255,7 @@ export let _$n_list_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
-  if (xs instanceof CalcitList) return xs.get(k);
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) return xs.get(k);
 
   throw new Error("Does not support `nth` on this type");
 };
@@ -282,7 +282,7 @@ export let _$n_record_$o_get = function (xs: CalcitValue, k: CalcitValue) {
 export let _$n_list_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
     }
@@ -318,11 +318,11 @@ export let _$n_record_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: C
   throw new Error("record `assoc` expected a record");
 };
 
-export let _$n_list_$o_assoc_before = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
+export let _$n_list_$o_assoc_before = function (xs: CalcitList | CalcitSliceList, k: number, v: CalcitValue): CalcitList {
   if (arguments.length !== 3) {
     throw new Error("assoc takes 3 arguments");
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
     }
@@ -332,11 +332,11 @@ export let _$n_list_$o_assoc_before = function (xs: CalcitList, k: number, v: Ca
   throw new Error("Does not support `assoc-before` on this type");
 };
 
-export let _$n_list_$o_assoc_after = function (xs: CalcitList, k: number, v: CalcitValue): CalcitList {
+export let _$n_list_$o_assoc_after = function (xs: CalcitSliceList, k: number, v: CalcitValue): CalcitList {
   if (arguments.length !== 3) {
     throw new Error("assoc takes 3 arguments");
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
     }
@@ -346,10 +346,10 @@ export let _$n_list_$o_assoc_after = function (xs: CalcitList, k: number, v: Cal
   throw new Error("Does not support `assoc-after` on this type");
 };
 
-export let _$n_list_$o_dissoc = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_list_$o_dissoc = function (xs: CalcitValue | CalcitSliceList, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("dissoc takes 2 arguments");
 
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (typeof k !== "number") throw new Error("Expected number index for lists");
 
     return xs.dissoc(k);
@@ -398,8 +398,8 @@ export let remove_watch = (a: CalcitRef, k: CalcitKeyword): null => {
   return null;
 };
 
-export let range = (n: number, m: number, m2: number): CalcitList => {
-  var result = new CalcitList([]);
+export let range = (n: number, m: number, m2: number): CalcitSliceList | CalcitList => {
+  var result: CalcitList | CalcitSliceList = new CalcitSliceList([]);
   if (m2 != null) {
     console.warn("TODO range with 3 arguments"); // TODO
   }
@@ -420,7 +420,7 @@ export let range = (n: number, m: number, m2: number): CalcitList => {
 };
 
 export function _$n_list_$o_empty_$q_(xs: CalcitValue): boolean {
-  if (xs instanceof CalcitList) return xs.isEmpty();
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) return xs.isEmpty();
   throw new Error(`expected a list ${xs}`);
 }
 export function _$n_str_$o_empty_$q_(xs: CalcitValue): boolean {
@@ -438,7 +438,7 @@ export function _$n_set_$o_empty_$q_(xs: CalcitValue): boolean {
 }
 
 export let _$n_list_$o_first = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (xs.isEmpty()) {
       return null;
     }
@@ -459,7 +459,7 @@ export let _$n_map_$o_first = (xs: CalcitValue): CalcitValue => {
     // TODO order may not be stable enough
     let ys = xs.pairs();
     if (ys.length > 0) {
-      return new CalcitList(ys[0]);
+      return new CalcitSliceList(ys[0]);
     } else {
       return null;
     }
@@ -488,7 +488,7 @@ export let timeout_call = (duration: number, f: CalcitFn): null => {
 };
 
 export let _$n_list_$o_rest = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (xs.len() === 0) {
       return null;
     }
@@ -536,21 +536,21 @@ export let not = (x: boolean): boolean => {
 };
 
 export let prepend = (xs: CalcitValue, v: CalcitValue): CalcitList => {
-  if (!(xs instanceof CalcitList)) {
+  if (!(xs instanceof CalcitList || xs instanceof CalcitSliceList)) {
     throw new Error("Expected array");
   }
   return xs.prepend(v);
 };
 
-export let append = (xs: CalcitValue, v: CalcitValue): CalcitList => {
-  if (!(xs instanceof CalcitList)) {
+export let append = (xs: CalcitValue, v: CalcitValue): CalcitList | CalcitSliceList => {
+  if (!(xs instanceof CalcitList || xs instanceof CalcitSliceList)) {
     throw new Error("Expected array");
   }
   return xs.append(v);
 };
 
 export let last = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (xs.isEmpty()) {
       return null;
     }
@@ -564,7 +564,7 @@ export let last = (xs: CalcitValue): CalcitValue => {
 };
 
 export let butlast = (xs: CalcitValue): CalcitValue => {
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     if (xs.len() === 0) {
       return null;
     }
@@ -603,7 +603,7 @@ export let _$n_display_stack = (): null => {
   return null;
 };
 
-export let _$n_list_$o_slice = (xs: CalcitList, from: number, to: number): CalcitList => {
+export let _$n_list_$o_slice = (xs: CalcitList, from: number, to: number): CalcitSliceList | CalcitList => {
   if (xs == null) {
     return null;
   }
@@ -611,20 +611,20 @@ export let _$n_list_$o_slice = (xs: CalcitList, from: number, to: number): Calci
   if (to == null) {
     to = size;
   } else if (to <= from) {
-    return new CalcitList([]);
+    return new CalcitSliceList([]);
   } else if (to > size) {
     to = size;
   }
   return xs.slice(from, to);
 };
 
-export let _$n_list_$o_concat = (...lists: CalcitList[]): CalcitList => {
-  let result: CalcitList = new CalcitList([]);
+export let _$n_list_$o_concat = (...lists: (CalcitList | CalcitSliceList)[]): CalcitList | CalcitSliceList => {
+  let result: CalcitSliceList | CalcitList = new CalcitSliceList([]);
   for (let item of lists) {
     if (item == null) {
       continue;
     }
-    if (item instanceof CalcitList) {
+    if (item instanceof CalcitList || item instanceof CalcitSliceList) {
       if (result.isEmpty()) {
         result = item;
       } else {
@@ -677,13 +677,13 @@ export let _$n_str_$o_concat = (a: string, b: string) => {
   }
   return buffer;
 };
-export let sort = (xs: CalcitList, f: CalcitFn): CalcitList => {
+export let sort = (xs: CalcitList | CalcitSliceList, f: CalcitFn): CalcitSliceList => {
   if (xs == null) {
     return null;
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     let ys = xs.toArray();
-    return new CalcitList(ys.sort(f as any));
+    return new CalcitSliceList(ys.sort(f as any));
   }
   throw new Error("Expected list");
 };
@@ -749,17 +749,17 @@ export let _$n_merge_non_nil = (a: CalcitMap, b: CalcitMap): CalcitMap => {
   return a.mergeSkip(b, null);
 };
 
-export let to_pairs = (xs: CalcitValue): CalcitValue => {
+export let to_pairs = (xs: CalcitValue): CalcitValue | CalcitSliceList => {
   if (xs instanceof CalcitMap) {
-    let result: Array<CalcitList> = [];
+    let result: Array<CalcitSliceList> = [];
     for (let [k, v] of xs.pairs()) {
-      result.push(new CalcitList([k, v]));
+      result.push(new CalcitSliceList([k, v]));
     }
     return new CalcitSet(result);
   } else if (xs instanceof CalcitRecord) {
-    let arr_result: Array<CalcitList> = [];
+    let arr_result: Array<CalcitSliceList> = [];
     for (let idx = 0; idx < xs.fields.length; idx++) {
-      arr_result.push(new CalcitList([xs.fields[idx], xs.values[idx]]));
+      arr_result.push(new CalcitSliceList([xs.fields[idx], xs.values[idx]]));
     }
     return new CalcitSet(arr_result);
   } else {
@@ -851,11 +851,11 @@ export let _$n_str_$o_replace = (x: string, y: string, z: string): string => {
   return result;
 };
 
-export let split = (xs: string, x: string): CalcitList => {
-  return new CalcitList(xs.split(x));
+export let split = (xs: string, x: string): CalcitSliceList => {
+  return new CalcitSliceList(xs.split(x));
 };
-export let split_lines = (xs: string): CalcitList => {
-  return new CalcitList(xs.split("\n"));
+export let split_lines = (xs: string): CalcitSliceList => {
+  return new CalcitSliceList(xs.split("\n"));
 };
 export let _$n_str_$o_slice = (xs: string, m: number, n: number): string => {
   if (n <= m) {
@@ -911,8 +911,8 @@ export let char_from_code = (n: number): string => {
   return String.fromCharCode(n);
 };
 
-export let _$n_set_$o_to_list = (x: CalcitSet): CalcitList => {
-  return new CalcitList(x.values());
+export let _$n_set_$o_to_list = (x: CalcitSet): CalcitSliceList => {
+  return new CalcitSliceList(x.values());
 };
 
 export let aget = (x: any, name: string): any => {
@@ -1046,15 +1046,15 @@ export let _$n_str_$o_compare = (x: string, y: string) => {
   return 0;
 };
 
-export let arrayToList = (xs: Array<CalcitValue>): CalcitList => {
-  return new CalcitList(xs ?? []);
+export let arrayToList = (xs: Array<CalcitValue>): CalcitSliceList => {
+  return new CalcitSliceList(xs ?? []);
 };
 
-export let listToArray = (xs: CalcitList): Array<CalcitValue> => {
+export let listToArray = (xs: CalcitList | CalcitSliceList): Array<CalcitValue> => {
   if (xs == null) {
     return null;
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     return xs.toArray();
   } else {
     throw new Error("Expected list");
@@ -1080,7 +1080,7 @@ export let map_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitMap;
 };
 export let list_$q_ = (x: CalcitValue): boolean => {
-  return x instanceof CalcitList;
+  return x instanceof CalcitList || x instanceof CalcitSliceList;
 };
 export let set_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitSet;
@@ -1136,7 +1136,7 @@ export let format_to_lisp = (x: CalcitValue): string => {
     return "nil";
   } else if (x instanceof CalcitSymbol) {
     return x.value;
-  } else if (x instanceof CalcitList) {
+  } else if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     let chunk = "(";
     for (let item of x.items()) {
       if (chunk != "(") {
@@ -1164,7 +1164,7 @@ export let transform_code_to_cirru = (x: CalcitValue): ICirruNode => {
     return "nil";
   } else if (x instanceof CalcitSymbol) {
     return x.value;
-  } else if (x instanceof CalcitList) {
+  } else if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     let xs: ICirruNode[] = [];
     for (let item of x.items()) {
       xs.push(transform_code_to_cirru(item));
@@ -1243,7 +1243,7 @@ export function invoke_method(p: string) {
       klass = calcit_builtin_classes.fn;
     } else if (obj instanceof CalcitSet) {
       klass = calcit_builtin_classes.set;
-    } else if (obj instanceof CalcitList) {
+    } else if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
       klass = calcit_builtin_classes.list;
     } else if (obj instanceof CalcitRecord) {
       klass = calcit_builtin_classes.record;
@@ -1268,13 +1268,13 @@ export function invoke_method(p: string) {
   };
 }
 
-export let _$n_map_$o_to_list = (m: CalcitValue): CalcitList => {
+export let _$n_map_$o_to_list = (m: CalcitValue): CalcitSliceList => {
   if (m instanceof CalcitMap) {
     let ys = [];
     for (let pair of m.pairs()) {
-      ys.push(new CalcitList(pair));
+      ys.push(new CalcitSliceList(pair));
     }
-    return new CalcitList(ys);
+    return new CalcitSliceList(ys);
   } else {
     throw new Error("&map:to-list expected a Map");
   }
@@ -1309,7 +1309,7 @@ let typeAsInt = (x: CalcitValue): number => {
   if (x instanceof CalcitRef) return PseudoTypeIndex.ref;
   if (x instanceof CalcitTuple) return PseudoTypeIndex.tuple;
   if (x instanceof CalcitRecur) return PseudoTypeIndex.recur;
-  if (x instanceof CalcitList) return PseudoTypeIndex.list;
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) return PseudoTypeIndex.list;
   if (x instanceof CalcitSet) return PseudoTypeIndex.set;
   if (x instanceof CalcitMap) return PseudoTypeIndex.map;
   if (x instanceof CalcitRecord) return PseudoTypeIndex.record;
@@ -1403,7 +1403,7 @@ export let _$n_list_$o_to_set = (xs: CalcitList): CalcitSet => {
   return new CalcitSet(result);
 };
 
-export let _$n_list_$o_distinct = (xs: CalcitList): CalcitList => {
+export let _$n_list_$o_distinct = (xs: CalcitList): CalcitSliceList => {
   var result: CalcitValue[] = [];
   let data = xs.toArray();
   outer: for (let idx = 0; idx < data.length; idx++) {
@@ -1414,7 +1414,7 @@ export let _$n_list_$o_distinct = (xs: CalcitList): CalcitList => {
     }
     result.push(data[idx]);
   }
-  return new CalcitList(result);
+  return new CalcitSliceList(result);
 };
 
 export let _$n_get_os = (): CalcitKeyword => {

--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.5.0-a23";
+export const calcit_version = "0.5.0-a24";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse, ICirruNode } from "@cirru/parser.ts";

--- a/ts-src/custom-formatter.ts
+++ b/ts-src/custom-formatter.ts
@@ -3,7 +3,7 @@ import { CalcitRef, CalcitSymbol, CalcitKeyword } from "./calcit-data";
 import { toPairs } from "@calcit/ternary-tree";
 
 import { CalcitRecord } from "./js-record";
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
@@ -49,7 +49,7 @@ export let load_console_formatter_$x_ = () => {
               ["span", { style: "font-size: 80%; vertical-align: 0.7em; color: hsl(280, 80%, 60%, 0.8)" }, `${obj.len()}`],
             ];
           }
-          if (obj instanceof CalcitMap) {
+          if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
             return ["div", { style: "color: hsl(280, 80%, 60%, 0.4)" }, obj.toString(true)];
           }
           if (obj instanceof CalcitSet) {
@@ -81,7 +81,7 @@ export let load_console_formatter_$x_ = () => {
           if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
             return obj.len() > 0;
           }
-          if (obj instanceof CalcitMap) {
+          if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
             return obj.len() > 0;
           }
           if (obj instanceof CalcitSet) {
@@ -117,10 +117,10 @@ export let load_console_formatter_$x_ = () => {
             ret.push(["div", { style: "margin-left: 8px; display: inline-block;" }, embedObject(obj.snd)]);
             return ret;
           }
-          if (obj instanceof CalcitMap) {
+          if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
             let ret: any[] = ["div", { style: "color: hsl(280, 80%, 60%)" }];
-            obj.turnMap();
-            for (let [k, v] of toPairs(obj.value)) {
+            let pairs = obj.pairs();
+            for (let [k, v] of pairs) {
               ret.push([
                 "div",
                 { style: "margin-left: 8px; display: flex;" },

--- a/ts-src/custom-formatter.ts
+++ b/ts-src/custom-formatter.ts
@@ -4,7 +4,7 @@ import { toPairs } from "@calcit/ternary-tree";
 
 import { CalcitRecord } from "./js-record";
 import { CalcitMap } from "./js-map";
-import { CalcitList } from "./js-list";
+import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
 
@@ -41,7 +41,7 @@ export let load_console_formatter_$x_ = () => {
           if (obj instanceof CalcitSymbol) {
             return ["div", { style: "color: hsl(340, 80%, 60%)" }, obj.toString()];
           }
-          if (obj instanceof CalcitList) {
+          if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
             return [
               "div",
               { style: "color: hsl(280, 80%, 60%, 0.4)" },
@@ -78,7 +78,7 @@ export let load_console_formatter_$x_ = () => {
           return null;
         },
         hasBody: (obj) => {
-          if (obj instanceof CalcitList) {
+          if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
             return obj.len() > 0;
           }
           if (obj instanceof CalcitMap) {
@@ -90,7 +90,7 @@ export let load_console_formatter_$x_ = () => {
           return false;
         },
         body: (obj, config) => {
-          if (obj instanceof CalcitList) {
+          if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
             return ["div", { style: "color: hsl(280, 80%, 60%)" }].concat(
               obj.toArray().map((x, idx) => {
                 return [

--- a/ts-src/js-cirru.ts
+++ b/ts-src/js-cirru.ts
@@ -2,7 +2,7 @@ import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { CirruWriterNode, writeCirruCode } from "@cirru/writer.ts";
 
 import { CalcitValue } from "./js-primes";
-import { CalcitList } from "./js-list";
+import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitRecord } from "./js-record";
 import { CalcitMap } from "./js-map";
 import { CalcitSet } from "./js-set";
@@ -44,7 +44,7 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
   if (x instanceof CalcitSymbol) {
     return x.toString();
   }
-  if (x instanceof CalcitList) {
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) {
     // TODO can be faster
     return (["[]"] as CirruEdnFormat[]).concat(x.toArray().map(to_cirru_edn));
   }
@@ -177,7 +177,7 @@ export let extract_cirru_edn = (x: CirruEdnFormat): CalcitValue => {
       return new CalcitRecord(extractFieldKwd(name), fields, values);
     }
     if (x[0] === "[]") {
-      return new CalcitList(x.slice(1).map(extract_cirru_edn));
+      return new CalcitSliceList(x.slice(1).map(extract_cirru_edn));
     }
     if (x[0] === "#{}") {
       return new CalcitSet(x.slice(1).map(extract_cirru_edn));
@@ -244,7 +244,7 @@ export let to_calcit_data = (x: any, noKeyword: boolean = false): CalcitValue =>
     x.forEach((v) => {
       result.push(to_calcit_data(v, noKeyword));
     });
-    return new CalcitList(result);
+    return new CalcitSliceList(result);
   }
   if (x instanceof Set) {
     let result: Array<CalcitValue> = [];
@@ -254,7 +254,7 @@ export let to_calcit_data = (x: any, noKeyword: boolean = false): CalcitValue =>
     return new CalcitSet(result);
   }
 
-  if (x instanceof CalcitList) return x;
+  if (x instanceof CalcitList || x instanceof CalcitSliceList) return x;
   if (x instanceof CalcitMap) return x;
   if (x instanceof CalcitSet) return x;
   if (x instanceof CalcitRecord) return x;
@@ -277,11 +277,11 @@ export let to_calcit_data = (x: any, noKeyword: boolean = false): CalcitValue =>
   throw new Error("Unexpected data for converting");
 };
 
-let toWriterNode = (xs: CalcitList): CirruWriterNode => {
+let toWriterNode = (xs: CalcitList | CalcitSliceList): CirruWriterNode => {
   if (typeof xs === "string") {
     return xs;
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     return xs.toArray().map(toWriterNode);
   } else {
     throw new Error("Unexpected type for CirruWriteNode");

--- a/ts-src/js-list.ts
+++ b/ts-src/js-list.ts
@@ -22,90 +22,39 @@ import { CalcitFn } from "./calcit.procs";
 
 import { isNestedCalcitData, tipNestedCalcitData, toString } from "./calcit-data";
 
+// two list implementations, should offer same interface
 export class CalcitList {
   value: TernaryTreeList<CalcitValue>;
   // array mode store bare array for performance
-  arrayValue: Array<CalcitValue>;
-  arrayMode: boolean;
-  arrayStart: number;
-  arrayEnd: number;
   cachedHash: Hash;
-  constructor(value: Array<CalcitValue> | TernaryTreeList<CalcitValue>) {
-    if (value == null) {
-      value = []; // dirty, better handled from outside
-    }
+  constructor(value: TernaryTreeList<CalcitValue>) {
     this.cachedHash = null;
-    if (Array.isArray(value)) {
-      this.arrayMode = true;
-      this.arrayValue = value;
-      this.arrayStart = 0;
-      this.arrayEnd = value.length;
-      this.value = null;
+    if (value == null) {
+      this.value = initTernaryTreeList([]);
     } else {
-      this.arrayMode = false;
       this.value = value;
-      this.arrayValue = [];
-      this.arrayStart = null;
-      this.arrayEnd = null;
-    }
-  }
-  turnListMode() {
-    if (this.arrayMode) {
-      this.value = initTernaryTreeList(this.arrayValue.slice(this.arrayStart, this.arrayEnd));
-      this.arrayValue = null;
-      this.arrayStart = null;
-      this.arrayEnd = null;
-      this.arrayMode = false;
     }
   }
   len() {
-    if (this.arrayMode) {
-      return this.arrayEnd - this.arrayStart;
-    } else {
-      return listLen(this.value);
-    }
+    return listLen(this.value);
   }
   get(idx: number) {
-    if (this.arrayMode) {
-      return this.arrayValue[this.arrayStart + idx];
-    } else {
-      return listGet(this.value, idx);
-    }
+    return listGet(this.value, idx);
   }
   assoc(idx: number, v: CalcitValue) {
-    this.turnListMode();
     return new CalcitList(assocList(this.value, idx, v));
   }
   assocBefore(idx: number, v: CalcitValue) {
-    this.turnListMode();
     return new CalcitList(assocBefore(this.value, idx, v));
   }
   assocAfter(idx: number, v: CalcitValue) {
-    this.turnListMode();
     return new CalcitList(assocAfter(this.value, idx, v));
   }
   dissoc(idx: number) {
-    this.turnListMode();
     return new CalcitList(dissocList(this.value, idx));
   }
   slice(from: number, to: number) {
-    if (this.arrayMode) {
-      if (from < 0) {
-        throw new Error(`from index too small: ${from}`);
-      }
-      if (to > this.len()) {
-        throw new Error(`end index too large: ${to}`);
-      }
-      if (to < from) {
-        throw new Error("end index too small");
-      }
-      let result = new CalcitList(this.arrayValue);
-      result.arrayStart = this.arrayStart + from;
-      result.arrayEnd = this.arrayStart + to;
-      return result;
-    } else {
-      return new CalcitList(ternaryTree.slice(this.value, from, to));
-    }
+    return new CalcitList(ternaryTree.slice(this.value, from, to));
   }
   toString(shorter = false): string {
     let result = "";
@@ -123,54 +72,142 @@ export class CalcitList {
   }
   /** usage: `for of` */
   items(): Generator<CalcitValue> {
-    if (this.arrayMode) {
-      return sliceGenerator(this.arrayValue, this.arrayStart, this.arrayEnd);
-    } else {
-      return listToItems(this.value);
-    }
+    return listToItems(this.value);
   }
   append(v: CalcitValue) {
-    if (this.arrayMode && this.arrayEnd === this.arrayValue.length && this.arrayStart < 32) {
-      // dirty trick to reuse list memory, data storage actually appended at existing array
-      this.arrayValue.push(v);
-      let newList = new CalcitList(this.arrayValue);
-      newList.arrayStart = this.arrayStart;
-      newList.arrayEnd = this.arrayEnd + 1;
-      return newList;
-    } else {
-      this.turnListMode();
-      return new CalcitList(ternaryTree.append(this.value, v));
-    }
+    return new CalcitList(ternaryTree.append(this.value, v));
   }
   prepend(v: CalcitValue) {
-    this.turnListMode();
     return new CalcitList(ternaryTree.prepend(this.value, v));
   }
   first() {
-    if (this.arrayMode) {
-      if (this.arrayValue.length > this.arrayStart) {
-        return this.arrayValue[this.arrayStart];
-      } else {
-        return null;
-      }
+    return ternaryTree.first(this.value);
+  }
+  rest() {
+    return new CalcitList(ternaryTree.rest(this.value));
+  }
+  concat(ys: CalcitList | CalcitSliceList) {
+    if (ys instanceof CalcitSliceList) {
+      return new CalcitList(ternaryTree.concat(this.value, ys.turnListMode().value));
+    } else if (ys instanceof CalcitList) {
+      return new CalcitList(ternaryTree.concat(this.value, ys.value));
     } else {
-      return ternaryTree.first(this.value);
+      throw new Error("Unknown data to concat");
+    }
+  }
+  map(f: (v: CalcitValue) => CalcitValue): CalcitList {
+    return new CalcitList(ternaryTree.listMapValues(this.value, f));
+  }
+  toArray(): CalcitValue[] {
+    return [...ternaryTree.listToItems(this.value)];
+  }
+  reverse() {
+    return new CalcitList(ternaryTree.reverse(this.value));
+  }
+}
+
+// represent append-only immutable list in Array slices
+export class CalcitSliceList {
+  // array mode store bare array for performance
+  value: Array<CalcitValue>;
+  arrayMode: boolean;
+  start: number;
+  end: number;
+  cachedHash: Hash;
+  constructor(value: Array<CalcitValue>) {
+    if (value == null) {
+      value = []; // dirty, better handled from outside
+    }
+    this.cachedHash = null;
+
+    this.value = value;
+    this.start = 0;
+    this.end = value.length;
+  }
+  turnListMode(): CalcitList {
+    return new CalcitList(initTernaryTreeList(this.value.slice(this.start, this.end)));
+  }
+  len() {
+    return this.end - this.start;
+  }
+  get(idx: number) {
+    return this.value[this.start + idx];
+  }
+  assoc(idx: number, v: CalcitValue) {
+    return this.turnListMode().assoc(idx, v);
+  }
+  assocBefore(idx: number, v: CalcitValue) {
+    return this.turnListMode().assocBefore(idx, v);
+  }
+  assocAfter(idx: number, v: CalcitValue) {
+    return this.turnListMode().assocAfter(idx, v);
+  }
+  dissoc(idx: number) {
+    return this.turnListMode().dissoc(idx);
+  }
+  slice(from: number, to: number) {
+    if (from < 0) {
+      throw new Error(`from index too small: ${from}`);
+    }
+    if (to > this.len()) {
+      throw new Error(`end index too large: ${to}`);
+    }
+    if (to < from) {
+      throw new Error("end index too small");
+    }
+    let result = new CalcitSliceList(this.value);
+    result.start = this.start + from;
+    result.end = this.start + to;
+    return result;
+  }
+  toString(shorter = false): string {
+    let result = "";
+    for (let item of this.items()) {
+      if (shorter && isNestedCalcitData(item)) {
+        result = `${result} ${tipNestedCalcitData(item)}`;
+      } else {
+        result = `${result} ${toString(item, true)}`;
+      }
+    }
+    return `([]${result})`;
+  }
+  isEmpty() {
+    return this.len() === 0;
+  }
+  /** usage: `for of` */
+  items(): Generator<CalcitValue> {
+    return sliceGenerator(this.value, this.start, this.end);
+  }
+  append(v: CalcitValue): CalcitSliceList | CalcitList {
+    if (this.arrayMode && this.end === this.value.length && this.start < 32) {
+      // dirty trick to reuse list memory, data storage actually appended at existing array
+      this.value.push(v);
+      let newList = new CalcitSliceList(this.value);
+      newList.start = this.start;
+      newList.end = this.end + 1;
+      return newList;
+    } else {
+      return this.turnListMode().append(v);
+    }
+  }
+  prepend(v: CalcitValue) {
+    return this.turnListMode().prepend(v);
+  }
+  first() {
+    if (this.value.length > this.start) {
+      return this.value[this.start];
+    } else {
+      return null;
     }
   }
   rest() {
-    if (this.arrayMode) {
-      return this.slice(1, this.arrayEnd - this.arrayStart);
-    } else {
-      return new CalcitList(ternaryTree.rest(this.value));
-    }
+    return this.slice(1, this.end - this.start);
   }
-  concat(ys: CalcitList) {
-    if (!(ys instanceof CalcitList)) {
-      throw new Error("Expected list");
-    }
-    if (this.arrayMode && ys.arrayMode) {
-      let size = this.arrayEnd - this.arrayStart;
-      let otherSize = ys.arrayEnd - ys.arrayStart;
+  // TODO
+  concat(ys: CalcitSliceList | CalcitList) {
+    if (ys instanceof CalcitSliceList) {
+      let size = this.end - this.start;
+      let otherSize = ys.end - ys.start;
       let combined = new Array(size + otherSize);
       for (let i = 0; i < size; i++) {
         combined[i] = this.get(i);
@@ -178,36 +215,38 @@ export class CalcitList {
       for (let i = 0; i < otherSize; i++) {
         combined[i + size] = ys.get(i);
       }
-      return new CalcitList(combined);
+      return new CalcitSliceList(combined);
+    } else if (ys instanceof CalcitList) {
+      return this.turnListMode().concat(ys);
     } else {
-      this.turnListMode();
-      ys.turnListMode();
-      return new CalcitList(ternaryTree.concat(this.value, ys.value));
+      throw new Error("Expected list");
     }
   }
-  map(f: (v: CalcitValue) => CalcitValue): CalcitList {
-    if (this.arrayMode) {
-      return new CalcitList(this.arrayValue.slice(this.arrayStart, this.arrayEnd).map(f));
-    } else {
-      return new CalcitList(ternaryTree.listMapValues(this.value, f));
+  map(f: (v: CalcitValue) => CalcitValue): CalcitSliceList {
+    let ys: CalcitValue[] = [];
+    for (let x in sliceGenerator(this.value, this.start, this.end)) {
+      ys.push(f(x));
     }
+
+    return new CalcitSliceList(ys);
   }
   toArray(): CalcitValue[] {
-    if (this.arrayMode) {
-      return this.arrayValue.slice(this.arrayStart, this.arrayEnd);
-    } else {
-      return [...ternaryTree.listToItems(this.value)];
-    }
+    return this.value.slice(this.start, this.end);
   }
   reverse() {
-    this.turnListMode();
-    return new CalcitList(ternaryTree.reverse(this.value));
+    return this.turnListMode().reverse();
   }
 }
 
 function* sliceGenerator(xs: Array<CalcitValue>, start: number, end: number): Generator<CalcitValue> {
-  for (let idx = start; idx < end; idx++) {
-    yield xs[idx];
+  if (xs == null) {
+    if (end <= start) {
+      throw new Error("invalid list to slice");
+    }
+  } else {
+    for (let idx = start; idx < end; idx++) {
+      yield xs[idx];
+    }
   }
 }
 
@@ -220,7 +259,7 @@ export let foldl = function (xs: CalcitValue, acc: CalcitValue, f: CalcitFn): Ca
     debugger;
     throw new Error("Expected function for folding");
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     var result = acc;
     for (let idx = 0; idx < xs.len(); idx++) {
       let item = xs.get(idx);
@@ -238,7 +277,7 @@ export let foldl = function (xs: CalcitValue, acc: CalcitValue, f: CalcitFn): Ca
   if (xs instanceof CalcitMap) {
     let result = acc;
     xs.pairs().forEach(([k, item]) => {
-      result = f(result, new CalcitList([k, item]));
+      result = f(result, new CalcitSliceList([k, item]));
     });
     return result;
   }
@@ -254,7 +293,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     debugger;
     throw new Error("Expected function for folding");
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     var state = acc;
     for (let idx = 0; idx < xs.len(); idx++) {
       let item = xs.get(idx);
@@ -295,7 +334,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
   if (xs instanceof CalcitMap) {
     let state = acc;
     for (let item of xs.pairs()) {
-      let pair = f(state, new CalcitList(item));
+      let pair = f(state, new CalcitSliceList(item));
       if (pair instanceof CalcitTuple) {
         if (typeof pair.fst === "boolean") {
           if (pair.fst) {
@@ -321,7 +360,7 @@ export let foldr_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     debugger;
     throw new Error("Expected function for folding");
   }
-  if (xs instanceof CalcitList) {
+  if (xs instanceof CalcitList || xs instanceof CalcitSliceList) {
     var state = acc;
     // iterate from right
     for (let idx = xs.len() - 1; idx >= 0; idx--) {

--- a/ts-src/js-list.ts
+++ b/ts-src/js-list.ts
@@ -15,7 +15,7 @@ import {
   assocAfter,
 } from "@calcit/ternary-tree";
 
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 import { CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
 import { CalcitFn } from "./calcit.procs";
@@ -274,7 +274,7 @@ export let foldl = function (xs: CalcitValue, acc: CalcitValue, f: CalcitFn): Ca
     });
     return result;
   }
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     let result = acc;
     xs.pairs().forEach(([k, item]) => {
       result = f(result, new CalcitSliceList([k, item]));
@@ -331,7 +331,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     return v0;
   }
 
-  if (xs instanceof CalcitMap) {
+  if (xs instanceof CalcitMap || xs instanceof CalcitSliceMap) {
     let state = acc;
     for (let item of xs.pairs()) {
       let pair = f(state, new CalcitSliceList(item));

--- a/ts-src/js-primes.ts
+++ b/ts-src/js-primes.ts
@@ -1,7 +1,7 @@
 import { CalcitKeyword, CalcitSymbol, CalcitRef, CalcitFn, CalcitRecur } from "./calcit-data";
 import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitRecord } from "./js-record";
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 import { CalcitSet as CalcitSet } from "./js-set";
 import { CalcitTuple } from "./js-tuple";
 
@@ -10,6 +10,7 @@ export type CalcitValue =
   | number
   | boolean
   | CalcitMap
+  | CalcitSliceMap
   | CalcitList
   | CalcitSliceList
   | CalcitSet

--- a/ts-src/js-primes.ts
+++ b/ts-src/js-primes.ts
@@ -1,5 +1,5 @@
-import { CalcitKeyword, CalcitSymbol as CalcitSymbol, CalcitRef, CalcitFn, CalcitRecur } from "./calcit-data";
-import { CalcitList } from "./js-list";
+import { CalcitKeyword, CalcitSymbol, CalcitRef, CalcitFn, CalcitRecur } from "./calcit-data";
+import { CalcitList, CalcitSliceList } from "./js-list";
 import { CalcitRecord } from "./js-record";
 import { CalcitMap } from "./js-map";
 import { CalcitSet as CalcitSet } from "./js-set";
@@ -11,6 +11,7 @@ export type CalcitValue =
   | boolean
   | CalcitMap
   | CalcitList
+  | CalcitSliceList
   | CalcitSet
   | CalcitKeyword
   | CalcitSymbol

--- a/ts-src/js-record.ts
+++ b/ts-src/js-record.ts
@@ -2,7 +2,7 @@ import { initTernaryTreeMap, Hash, insert } from "@calcit/ternary-tree";
 import { CalcitValue } from "./js-primes";
 import { kwd, castKwd, toString, CalcitKeyword, getStringName, findInFields } from "./calcit-data";
 
-import { CalcitMap } from "./js-map";
+import { CalcitMap, CalcitSliceMap } from "./js-map";
 
 export class CalcitRecord {
   name: CalcitKeyword;
@@ -152,7 +152,7 @@ export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): Cal
       }
       return new CalcitRecord(proto.name, proto.fields, values);
     }
-  } else if (data instanceof CalcitMap) {
+  } else if (data instanceof CalcitMap || data instanceof CalcitSliceMap) {
     let pairs: Array<[CalcitKeyword, CalcitValue]> = [];
     for (let [k, v] of data.pairs()) {
       pairs.push([castKwd(k), v]);
@@ -179,11 +179,11 @@ export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): Cal
 
 export let _$n_record_$o_to_map = (x: CalcitValue): CalcitValue => {
   if (x instanceof CalcitRecord) {
-    var dict: Array<[CalcitValue, CalcitValue]> = [];
+    var dict: Array<CalcitValue> = [];
     for (let idx = 0; idx < x.fields.length; idx++) {
-      dict.push([x.fields[idx], x.values[idx]]);
+      dict.push(x.fields[idx], x.values[idx]);
     }
-    return new CalcitMap(initTernaryTreeMap(dict));
+    return new CalcitSliceMap(dict);
   } else {
     throw new Error("Expected record");
   }


### PR DESCRIPTION
tested with Respo, the demo went from 60..90 to 70..110 relatively.
tested with Cumulo Timegrass, stable memory went from 25M to 18M, observed in activities monitor.

very rough comparison, but should reduce memory usages a bit. future improvements are requested...
