### PR TITLE
Try FingerTree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,8 @@ dependencies = [
  "clap",
  "ctrlc",
  "dirs",
+ "fingertrees",
  "hex",
- "im_ternary_tree",
  "lazy_static",
  "libloading",
  "notify",
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fingertrees"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d1bc3d4880c54d4a11a70af7bc3e5c59f4b384ddfe4c42735d5a317c0abf21"
+
+[[package]]
 name = "fsevent"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,12 +219,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "im_ternary_tree"
-version = "0.0.1-a8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88022c35e7fe221e0bac9d91a051e5ffd32df85370f640e4aa1ef6d1d2ebc4b"
 
 [[package]]
 name = "inotify"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "fingertrees"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d1bc3d4880c54d4a11a70af7bc3e5c59f4b384ddfe4c42735d5a317c0abf21"
+checksum = "53b67d8f49456811373ba887e9f86c1fa0ac4cd934ece3a095331e446b0f6ed0"
 
 [[package]]
 name = "fsevent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cirru_edn"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ee334f8cc2ee791e8f0df7f934a50ce4cb48d2169b3d1bf7a3b2fbace3564a"
+checksum = "012e2628ebf44d21550bdf516f37b4d0556fd96b2f040a94f337bdc3235eaa6f"
 dependencies = [
  "cirru_parser",
  "hex",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_parser"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5004e11be1bc491748d59b73e3e0ad4f73ff2bbb47e0a9b3e205a83dc416fde"
+checksum = "2d1cdf9af6d166ca8d8da5cd6fe2cc7ca9729d28ab5333e731322b7c4fbc2743"
 
 [[package]]
 name = "clap"
@@ -279,9 +279,9 @@ checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.2.11"
+cirru_edn = "0.2.12"
 # cirru_edn = { path = "/Users/chen/repo/cirru/edn.rs" }
-cirru_parser = "0.1.16"
+cirru_parser = "0.1.17"
 clap = "2.33.3"
 dirs = "4.0.0"
 lazy_static = "1.4.0"
@@ -30,12 +30,10 @@ notify = "4.0.17"
 walkdir = "2"
 hex = "0.4.3"
 rpds = "0.10.0"
-# im_ternary_tree = "=0.0.1-a8"
-# im_ternary_tree = { path = "/Users/chen/repo/calcit-lang/ternary-tree" }
 fingertrees = "0.2.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libloading = "0.7.1"
+libloading = "0.7.2"
 ctrlc = "3.2.1"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hex = "0.4.3"
 rpds = "0.10.0"
 # im_ternary_tree = "=0.0.1-a8"
 # im_ternary_tree = { path = "/Users/chen/repo/calcit-lang/ternary-tree" }
-fingertrees = "0.2.5"
+fingertrees = "0.2.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ notify = "4.0.17"
 walkdir = "2"
 hex = "0.4.3"
 rpds = "0.10.0"
-im_ternary_tree = "=0.0.1-a8"
+# im_ternary_tree = "=0.0.1-a8"
 # im_ternary_tree = { path = "/Users/chen/repo/calcit-lang/ternary-tree" }
+fingertrees = "0.2.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading = "0.7.1"

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), String> {
 
     let data = cirru_edn::parse(&content)?;
     // println!("reading: {}", content);
-    snapshot = snapshot::load_snapshot_data(data, cli_options.entry_path.to_str().unwrap())?;
+    snapshot = snapshot::load_snapshot_data(&data, cli_options.entry_path.to_str().unwrap())?;
 
     // config in entry will overwrite default configs
     if let Some(entry) = cli_matches.value_of("entry") {
@@ -227,7 +227,7 @@ fn recall_program(content: &str, entries: &ProgramEntries, settings: &CLIOptions
   // 3. rerun program, and catch error
 
   let data = cirru_edn::parse(content)?;
-  let changes = snapshot::load_changes_info(data)?;
+  let changes = snapshot::load_changes_info(&data)?;
 
   // println!("\ndata: {}", &data);
   // println!("\nchanges: {:?}", changes);

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "128"]
-
 use std::cell::RefCell;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -14,8 +14,8 @@ mod injection;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 
 use calcit_runner::{
-  builtins, call_stack, cli_args, codegen, codegen::emit_js::gen_stack, codegen::COMPILE_ERRORS_FILE, program, runner, snapshot, util,
-  ProgramEntries,
+  builtins, call_stack, cli_args, codegen, codegen::emit_js::gen_stack, codegen::COMPILE_ERRORS_FILE, primes::finger_list::FingerList,
+  program, runner, snapshot, util, ProgramEntries,
 };
 
 pub struct CLIOptions {

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1,4 +1,3 @@
-use crate::primes::finger_list::FingerList;
 use crate::runner;
 use cirru_edn::Edn;
 use std::sync::Arc;
@@ -8,7 +7,7 @@ use calcit_runner::{
   builtins,
   call_stack::{display_stack, CallStackList},
   data::edn::{calcit_to_edn, edn_to_calcit},
-  primes::{Calcit, CalcitErr, CalcitItems, CrListWrap},
+  primes::{finger_list::FingerList, Calcit, CalcitErr, CalcitItems, CrListWrap},
   runner::track,
 };
 

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1,3 +1,4 @@
+use crate::primes::finger_list::FingerList;
 use crate::runner;
 use cirru_edn::Edn;
 use std::sync::Arc;
@@ -10,7 +11,6 @@ use calcit_runner::{
   primes::{Calcit, CalcitErr, CalcitItems, CrListWrap},
   runner::track,
 };
-use im_ternary_tree::TernaryTreeList;
 
 /// FFI protocol types
 type EdnFfi = fn(args: Vec<Edn>) -> Result<Edn, String>;
@@ -138,7 +138,7 @@ pub fn call_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Result
           def_ns, scope, args, body, ..
         } = &callback
         {
-          let mut real_args = TernaryTreeList::Empty;
+          let mut real_args = FingerList::new_empty();
           for p in ps {
             real_args = real_args.push(edn_to_calcit(&p));
           }
@@ -226,7 +226,7 @@ pub fn blocking_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Re
         def_ns, scope, args, body, ..
       } = &callback
       {
-        let mut real_args = TernaryTreeList::Empty;
+        let mut real_args = FingerList::new_empty();
         for p in ps {
           real_args = real_args.push(edn_to_calcit(&p));
         }
@@ -269,7 +269,7 @@ pub fn on_ctrl_c(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit,
       } = cb.as_ref()
       {
         if let Err(e) = runner::run_fn(
-          &TernaryTreeList::Empty,
+          &FingerList::new_empty(),
           scope,
           args.to_owned(),
           body,

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -5,9 +5,8 @@ use crate::util::number::f64_to_usize;
 
 use crate::builtins;
 use crate::call_stack::CallStackList;
+use crate::primes::finger_list::FingerList;
 use crate::runner;
-
-use im_ternary_tree::TernaryTreeList;
 
 pub fn new_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   Ok(Calcit::List(xs.to_owned()))
@@ -115,7 +114,7 @@ pub fn butlast(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 }
 
 pub fn concat(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
-  let mut ys: CalcitItems = TernaryTreeList::Empty;
+  let mut ys: CalcitItems = FingerList::new_empty();
   for x in xs {
     if let Calcit::List(zs) = x {
       for z in zs {
@@ -145,14 +144,14 @@ pub fn range(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   };
 
   if (bound - base).abs() < f64::EPSILON {
-    return Ok(Calcit::List(TernaryTreeList::Empty));
+    return Ok(Calcit::List(FingerList::new_empty()));
   }
 
   if step == 0.0 || (bound > base && step < 0.0) || (bound < base && step > 0.0) {
     return CalcitErr::err_str("range cannot construct list with step 0");
   }
 
-  let mut ys: CalcitItems = TernaryTreeList::Empty;
+  let mut ys: CalcitItems = FingerList::new_empty();
   let mut i = base;
   if step > 0.0 {
     while i < bound {
@@ -193,7 +192,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
         },
       ) => {
         for x in xs {
-          let values = TernaryTreeList::from(&[ret, x.to_owned()]);
+          let values = FingerList::from(&[ret, x.to_owned()]);
           ret = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
         }
         Ok(ret)
@@ -201,7 +200,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
       (Calcit::List(xs), Calcit::Proc(proc)) => {
         for x in xs {
           // println!("foldl args, {} {}", ret, x.to_owned());
-          ret = builtins::handle_proc(proc, &TernaryTreeList::from(&[ret, x.to_owned()]), call_stack)?;
+          ret = builtins::handle_proc(proc, &FingerList::from(&[ret, x.to_owned()]), call_stack)?;
         }
         Ok(ret)
       }
@@ -213,7 +212,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
         },
       ) => {
         for x in xs {
-          let values = TernaryTreeList::from(&[ret, x.to_owned()]);
+          let values = FingerList::from(&[ret, x.to_owned()]);
           ret = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
         }
         Ok(ret)
@@ -221,7 +220,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
       (Calcit::Set(xs), Calcit::Proc(proc)) => {
         for x in xs {
           // println!("foldl args, {} {}", ret, x.to_owned());
-          ret = builtins::handle_proc(proc, &TernaryTreeList::from(&[ret, x.to_owned()]), call_stack)?;
+          ret = builtins::handle_proc(proc, &FingerList::from(&[ret, x.to_owned()]), call_stack)?;
         }
         Ok(ret)
       }
@@ -233,7 +232,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
         },
       ) => {
         for (k, x) in xs {
-          let values = TernaryTreeList::from(&[ret, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
+          let values = FingerList::from(&[ret, Calcit::List(FingerList::from(&[k.to_owned(), x.to_owned()]))]);
           ret = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
         }
         Ok(ret)
@@ -243,7 +242,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
           // println!("foldl args, {} {}", ret, x.to_owned());
           ret = builtins::handle_proc(
             proc,
-            &TernaryTreeList::from(&[ret, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]),
+            &FingerList::from(&[ret, Calcit::List(FingerList::from(&[k.to_owned(), x.to_owned()]))]),
             call_stack,
           )?;
         }
@@ -279,7 +278,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
       ) => {
         let mut state = acc.to_owned();
         for x in xs {
-          let values = TernaryTreeList::from(&[state, x.to_owned()]);
+          let values = FingerList::from(&[state, x.to_owned()]);
           let pair = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
           match pair {
             Calcit::Tuple(x0, x1) => match &*x0 {
@@ -316,7 +315,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
       ) => {
         let mut state = acc.to_owned();
         for x in xs {
-          let values = TernaryTreeList::from(&[state, x.to_owned()]);
+          let values = FingerList::from(&[state, x.to_owned()]);
           let pair = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
           match pair {
             Calcit::Tuple(x0, x1) => match &*x0 {
@@ -353,7 +352,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
       ) => {
         let mut state = acc.to_owned();
         for (k, x) in xs {
-          let values = TernaryTreeList::from(&[state, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
+          let values = FingerList::from(&[state, Calcit::List(FingerList::from(&[k.to_owned(), x.to_owned()]))]);
           let pair = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
           match pair {
             Calcit::Tuple(x0, x1) => match &*x0 {
@@ -413,7 +412,7 @@ pub fn foldr_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         let size = xs.len();
         for i in 0..size {
           let x = xs[size - 1 - i].to_owned();
-          let values = TernaryTreeList::from(&[state, x]);
+          let values = FingerList::from(&[state, x]);
           let pair = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
           match pair {
             Calcit::Tuple(x0, x1) => match &*x0 {
@@ -467,7 +466,7 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
       ) => {
         let mut xs2: Vec<&Calcit> = xs.into_iter().collect::<Vec<&Calcit>>();
         xs2.sort_by(|a, b| -> Ordering {
-          let values = TernaryTreeList::from(&[a.to_owned().to_owned(), b.to_owned().to_owned()]);
+          let values = FingerList::from(&[a.to_owned().to_owned(), b.to_owned().to_owned()]);
           let v = runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack);
           match v {
             Ok(Calcit::Number(x)) if x < 0.0 => Ordering::Less,
@@ -483,7 +482,7 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
             }
           }
         });
-        let mut ys: TernaryTreeList<Calcit> = TernaryTreeList::Empty;
+        let mut ys: FingerList<Calcit> = FingerList::new_empty();
         for x in xs2.iter() {
           // TODO ??
           ys = ys.push(x.to_owned().to_owned())
@@ -493,7 +492,7 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
       (Calcit::List(xs), Calcit::Proc(proc)) => {
         let mut xs2: Vec<&Calcit> = xs.into_iter().collect::<Vec<&Calcit>>();
         xs2.sort_by(|a, b| -> Ordering {
-          let values = TernaryTreeList::from(&[a.to_owned().to_owned(), b.to_owned().to_owned()]);
+          let values = FingerList::from(&[a.to_owned().to_owned(), b.to_owned().to_owned()]);
           let v = builtins::handle_proc(proc, &values, call_stack);
           match v {
             Ok(Calcit::Number(x)) if x < 0.0 => Ordering::Less,
@@ -509,7 +508,7 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
             }
           }
         });
-        let mut ys: TernaryTreeList<Calcit> = TernaryTreeList::Empty;
+        let mut ys: FingerList<Calcit> = FingerList::new_empty();
         for x in xs2.iter() {
           // TODO ??
           ys = ys.push(x.to_owned().to_owned())
@@ -664,7 +663,7 @@ pub fn distinct(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   }
   match &xs[0] {
     Calcit::List(ys) => {
-      let mut zs = TernaryTreeList::Empty;
+      let mut zs = FingerList::new_empty();
       for y in ys {
         if zs.index_of(y).is_none() {
           zs = zs.push(y.to_owned());

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -102,18 +102,20 @@ pub fn to_pairs(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     Some(Calcit::Map(ys)) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for (k, v) in ys {
-        zs.insert_mut(Calcit::List(FingerList::new_empty().push(k.to_owned()).push(v.to_owned())));
+        zs.insert_mut(Calcit::List(Arc::new(
+          FingerList::new_empty().push(k.to_owned()).push(v.to_owned()),
+        )));
       }
       Ok(Calcit::Set(zs))
     }
     Some(Calcit::Record(_name, fields, values)) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for idx in 0..fields.len() {
-        zs.insert_mut(Calcit::List(
+        zs.insert_mut(Calcit::List(Arc::new(
           FingerList::new_empty()
             .push(Calcit::Keyword(fields[idx].to_owned()))
             .push(values[idx].to_owned()),
-        ));
+        )));
       }
       Ok(Calcit::Set(zs))
     }
@@ -145,9 +147,9 @@ pub fn to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
       let mut ys: FingerList<Calcit> = FingerList::new_empty();
       for (k, v) in m {
         let zs: FingerList<Calcit> = FingerList::from(&[k.to_owned(), v.to_owned()]);
-        ys = ys.push(Calcit::List(zs));
+        ys = ys.push(Calcit::List(Arc::new(zs)));
       }
-      Ok(Calcit::List(ys))
+      Ok(Calcit::List(Arc::new(ys)))
     }
     Some(a) => CalcitErr::err_str(format!("&map:to-list expected a map, got: {}", a)),
     None => CalcitErr::err_str("&map:to-list expected a map, got nothing"),
@@ -198,7 +200,7 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Map(ys)) => match ys.iter().next() {
       // TODO order may not be stable enough
-      Some((k, v)) => Ok(Calcit::List(FingerList::from(&[k.to_owned(), v.to_owned()]))),
+      Some((k, v)) => Ok(Calcit::List(Arc::new(FingerList::from(&[k.to_owned(), v.to_owned()])))),
       None => Ok(Calcit::Nil),
     },
     Some(a) => CalcitErr::err_str(format!("map:first expected a map, got: {}", a)),

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use cirru_edn::EdnKwd;
-use im_ternary_tree::TernaryTreeList;
 
 use crate::builtins::records::find_in_fields;
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems, CrListWrap};
 
 use crate::util::number::is_even;
@@ -102,9 +102,7 @@ pub fn to_pairs(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     Some(Calcit::Map(ys)) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for (k, v) in ys {
-        zs.insert_mut(Calcit::List(
-          TernaryTreeList::Empty.append(k.to_owned(), false).append(v.to_owned(), false),
-        ));
+        zs.insert_mut(Calcit::List(FingerList::new_empty().push(k.to_owned()).push(v.to_owned())));
       }
       Ok(Calcit::Set(zs))
     }
@@ -112,9 +110,9 @@ pub fn to_pairs(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for idx in 0..fields.len() {
         zs.insert_mut(Calcit::List(
-          TernaryTreeList::Empty
-            .append(Calcit::Keyword(fields[idx].to_owned()), false)
-            .append(values[idx].to_owned(), false),
+          FingerList::new_empty()
+            .push(Calcit::Keyword(fields[idx].to_owned()))
+            .push(values[idx].to_owned()),
         ));
       }
       Ok(Calcit::Set(zs))
@@ -144,9 +142,9 @@ pub fn call_merge_non_nil(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 pub fn to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Map(m)) => {
-      let mut ys: TernaryTreeList<Calcit> = TernaryTreeList::Empty;
+      let mut ys: FingerList<Calcit> = FingerList::new_empty();
       for (k, v) in m {
-        let zs: TernaryTreeList<Calcit> = TernaryTreeList::from(&[k.to_owned(), v.to_owned()]);
+        let zs: FingerList<Calcit> = FingerList::from(&[k.to_owned(), v.to_owned()]);
         ys = ys.push(Calcit::List(zs));
       }
       Ok(Calcit::List(ys))
@@ -200,7 +198,7 @@ pub fn first(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Map(ys)) => match ys.iter().next() {
       // TODO order may not be stable enough
-      Some((k, v)) => Ok(Calcit::List(TernaryTreeList::from(&[k.to_owned(), v.to_owned()]))),
+      Some((k, v)) => Ok(Calcit::List(FingerList::from(&[k.to_owned(), v.to_owned()]))),
       None => Ok(Calcit::Nil),
     },
     Some(a) => CalcitErr::err_str(format!("map:first expected a map, got: {}", a)),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -49,7 +49,7 @@ pub fn type_of(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 }
 
 pub fn recur(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
-  Ok(Calcit::Recur(xs.to_owned()))
+  Ok(Calcit::Recur(Arc::new(xs.to_owned())))
 }
 
 pub fn format_to_lisp(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
@@ -72,7 +72,7 @@ fn transform_code_to_cirru(x: &Calcit) -> Cirru {
   match x {
     Calcit::List(ys) => {
       let mut xs: Vec<Cirru> = Vec::with_capacity(ys.len());
-      for y in ys {
+      for y in &**ys {
         xs.push(transform_code_to_cirru(y));
       }
       Cirru::List(xs)

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use cirru_edn::EdnKwd;
-use im_ternary_tree::TernaryTreeList;
 
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems, CalcitScope};
 use crate::{call_stack::CallStackList, runner};
 
@@ -35,7 +35,7 @@ fn modify_ref(path: Arc<str>, v: Calcit, call_stack: &CallStackList) -> Result<(
       Calcit::Fn {
         def_ns, scope, args, body, ..
       } => {
-        let values = TernaryTreeList::from(&[v.to_owned(), prev.to_owned()]);
+        let values = FingerList::from(&[v.to_owned(), prev.to_owned()]);
         runner::run_fn(&values, scope, args.to_owned(), body, def_ns.to_owned(), call_stack)?;
       }
       a => {

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -1,5 +1,5 @@
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems};
-use im_ternary_tree::TernaryTreeList;
 
 pub fn new_set(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   let mut ys = rpds::HashTrieSet::new_sync();
@@ -80,7 +80,7 @@ pub fn call_intersection(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 pub fn set_to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Set(xs)) => {
-      let mut ys: CalcitItems = TernaryTreeList::Empty;
+      let mut ys: CalcitItems = FingerList::new_empty();
       for x in xs {
         ys = ys.push(x.to_owned());
       }

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -1,5 +1,6 @@
 use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems};
+use std::sync::Arc;
 
 pub fn new_set(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   let mut ys = rpds::HashTrieSet::new_sync();
@@ -84,7 +85,7 @@ pub fn set_to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
       for x in xs {
         ys = ys.push(x.to_owned());
       }
-      Ok(Calcit::List(ys))
+      Ok(Calcit::List(Arc::new(ys)))
     }
     Some(a) => CalcitErr::err_str(format!("&set:to-list expected a set: {}", a)),
     None => CalcitErr::err_str("&set:to-list expected 1 argument, got none"),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -1,5 +1,6 @@
 use std::char;
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use crate::primes;
 use crate::primes::finger_list::FingerList;
@@ -67,7 +68,7 @@ pub fn split(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
           ys = ys.push(Calcit::Str(p.to_owned().into()));
         }
       }
-      Ok(Calcit::List(ys))
+      Ok(Calcit::List(Arc::new(ys)))
     }
     (Some(a), Some(b)) => CalcitErr::err_str(format!("split expected 2 strings, got: {} {}", a, b)),
     (_, _) => CalcitErr::err_str("split expected 2 arguments, got nothing"),
@@ -103,7 +104,7 @@ pub fn split_lines(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
       for line in lines {
         ys = ys.push(Calcit::Str(line.to_owned().into()));
       }
-      Ok(Calcit::List(ys))
+      Ok(Calcit::List(Arc::new(ys)))
     }
     Some(a) => CalcitErr::err_str(format!("split-lines expected 1 string, got: {}", a)),
     _ => CalcitErr::err_str("split-lines expected 1 argument, got nothing"),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -2,10 +2,9 @@ use std::char;
 use std::cmp::Ordering;
 
 use crate::primes;
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems, CrListWrap};
 use crate::util::number::f64_to_usize;
-
-use im_ternary_tree::TernaryTreeList;
 
 pub fn binary_str_concat(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
@@ -62,7 +61,7 @@ pub fn split(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match (xs.get(0), xs.get(1)) {
     (Some(Calcit::Str(s)), Some(Calcit::Str(pattern))) => {
       let pieces = (**s).split(&**pattern);
-      let mut ys: CalcitItems = TernaryTreeList::Empty;
+      let mut ys: CalcitItems = FingerList::new_empty();
       for p in pieces {
         if !p.is_empty() {
           ys = ys.push(Calcit::Str(p.to_owned().into()));
@@ -100,7 +99,7 @@ pub fn split_lines(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Str(s)) => {
       let lines = s.split('\n');
-      let mut ys = TernaryTreeList::Empty;
+      let mut ys = FingerList::new_empty();
       for line in lines {
         ys = ys.push(Calcit::Str(line.to_owned().into()));
       }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -193,7 +193,7 @@ pub fn macroexpand(
   if expr.len() == 1 {
     let quoted_code = runner::evaluate_expr(&expr[0], scope, file_ns.to_owned(), call_stack)?;
 
-    match quoted_code.to_owned() {
+    match &quoted_code {
       Calcit::List(xs) => {
         if xs.is_empty() {
           return Ok(quoted_code);
@@ -219,7 +219,7 @@ pub fn macroexpand(
           _ => Ok(quoted_code),
         }
       }
-      a => Ok(a),
+      a => Ok(a.to_owned()),
     }
   } else {
     CalcitErr::err_str(format!("macroexpand expected excaclty 1 argument, got: {:?}", expr))
@@ -235,7 +235,7 @@ pub fn macroexpand_1(
   if expr.len() == 1 {
     let quoted_code = runner::evaluate_expr(&expr[0], scope, file_ns.to_owned(), call_stack)?;
     // println!("quoted: {}", quoted_code);
-    match quoted_code.to_owned() {
+    match &quoted_code {
       Calcit::List(xs) => {
         if xs.is_empty() {
           return Ok(quoted_code);
@@ -249,7 +249,7 @@ pub fn macroexpand_1(
           _ => Ok(quoted_code),
         }
       }
-      a => Ok(a),
+      a => Ok(a.to_owned()),
     }
   } else {
     CalcitErr::err_str(format!("macroexpand expected excaclty 1 argument, got: {:?}", expr))
@@ -265,7 +265,7 @@ pub fn macroexpand_all(
   if expr.len() == 1 {
     let quoted_code = runner::evaluate_expr(&expr[0], scope, file_ns.to_owned(), call_stack)?;
 
-    match quoted_code.to_owned() {
+    match &quoted_code {
       Calcit::List(xs) => {
         if xs.is_empty() {
           return Ok(quoted_code);
@@ -314,7 +314,7 @@ pub fn macroexpand_all(
           }
         }
       }
-      a => Ok(a),
+      a => Ok(a.to_owned()),
     }
   } else {
     CalcitErr::err_str(format!("macroexpand expected excaclty 1 argument, got: {:?}", expr))

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 pub struct CalcitStack {
   pub ns: Arc<str>,
   pub def: Arc<str>,
-  pub code: Arc<Calcit>, // built in functions may not contain code
+  pub code: Calcit, // built in functions may not contain code
   pub args: CalcitItems,
   pub kind: StackKind,
 }
@@ -48,7 +48,7 @@ pub fn extend_call_stack(
   stack.push_front(CalcitStack {
     ns: ns.to_owned(),
     def: def.to_owned(),
-    code: Arc::new(code),
+    code: code.to_owned(),
     args: args.to_owned(),
     kind,
   })

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 pub struct CalcitStack {
   pub ns: Arc<str>,
   pub def: Arc<str>,
-  pub code: Calcit, // built in functions may not contain code
+  pub code: Arc<Calcit>, // built in functions may not contain code
   pub args: CalcitItems,
   pub kind: StackKind,
 }
@@ -48,7 +48,7 @@ pub fn extend_call_stack(
   stack.push_front(CalcitStack {
     ns: ns.to_owned(),
     def: def.to_owned(),
-    code,
+    code: Arc::new(code),
     args: args.to_owned(),
     kind,
   })

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -169,7 +169,7 @@ fn quote_to_js(xs: &Calcit, var_prefix: &str, keywords: &RefCell<Vec<EdnKwd>>) -
     Calcit::Proc(p) => Ok(format!("new {}CalcitSymbol({})", var_prefix, escape_cirru_str(p))),
     Calcit::List(ys) => {
       let mut chunk = String::from("");
-      for y in ys {
+      for y in &**ys {
         if !chunk.is_empty() {
           chunk.push_str(", ");
         }
@@ -388,7 +388,7 @@ fn gen_call_code(
     }
     Calcit::Symbol { sym: s, .. } | Calcit::Proc(s) => {
       match &**s {
-        ";" => Ok(format!("(/* {} */ null)", Calcit::List(body))),
+        ";" => Ok(format!("(/* {} */ null)", Calcit::List(Arc::new(body)))),
 
         "raise" => {
           // not core syntax, but treat as macro for better debugging experience
@@ -926,7 +926,7 @@ fn uses_recur(xs: &Calcit) -> bool {
       Some(Calcit::Syntax(syn, _)) if syn == &CalcitSyntax::Defn => false,
       Some(Calcit::Symbol { sym, .. }) if &**sym == "defn" => false,
       _ => {
-        for y in ys {
+        for y in &**ys {
           if uses_recur(y) {
             return true;
           }
@@ -1078,7 +1078,7 @@ fn contains_symbol(xs: &Calcit, y: &str) -> bool {
       false
     }
     Calcit::List(zs) => {
-      for z in zs {
+      for z in &**zs {
         if contains_symbol(z, y) {
           return true;
         }

--- a/src/codegen/emit_js/gen_stack.rs
+++ b/src/codegen/emit_js/gen_stack.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use crate::call_stack::{CalcitStack, CallStackList, StackKind};
 use crate::primes::{Calcit, CalcitItems};
@@ -12,7 +12,7 @@ pub fn push_call_stack(ns: &str, def: &str, kind: StackKind, code: Calcit, args:
   stack.push_front_mut(CalcitStack {
     ns: ns.into(),
     def: def.into(),
-    code: Arc::new(code),
+    code,
     args: args.to_owned(),
     kind,
   })

--- a/src/codegen/emit_js/gen_stack.rs
+++ b/src/codegen/emit_js/gen_stack.rs
@@ -1,4 +1,4 @@
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use crate::call_stack::{CalcitStack, CallStackList, StackKind};
 use crate::primes::{Calcit, CalcitItems};
@@ -12,7 +12,7 @@ pub fn push_call_stack(ns: &str, def: &str, kind: StackKind, code: Calcit, args:
   stack.push_front_mut(CalcitStack {
     ns: ns.into(),
     def: def.into(),
-    code,
+    code: Arc::new(code),
     args: args.to_owned(),
     kind,
   })

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -197,7 +197,7 @@ fn dump_code(code: &Calcit) -> Edn {
     Calcit::Thunk(code, _) => dump_code(code),
     Calcit::List(xs) => {
       let mut ys: Vec<Edn> = Vec::with_capacity(xs.len());
-      for x in xs {
+      for x in &**xs {
         ys.push(dump_code(x));
       }
       Edn::List(ys)

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -1,6 +1,6 @@
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitItems};
 use cirru_parser::Cirru;
-use im_ternary_tree::TernaryTreeList;
 use std::sync::Arc;
 
 /// code is CirruNode, and this function parse code(rather than data)
@@ -44,7 +44,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
           Err(e) => Err(format!("failed to parse hex: {} => {:?}", s, e)),
         },
         '\'' if s.len() > 1 => Ok(Calcit::List(
-          TernaryTreeList::Empty
+          FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("quote").into(),
               ns: ns.to_owned(),
@@ -60,7 +60,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
         )),
         // TODO also detect simple variables
         '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(
-          TernaryTreeList::Empty
+          FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("~@").into(),
               ns: ns.to_owned(),
@@ -75,7 +75,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
             }),
         )),
         '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(
-          TernaryTreeList::Empty
+          FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("~").into(),
               ns: ns.to_owned(),
@@ -90,7 +90,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
             }),
         )),
         '@' => Ok(Calcit::List(
-          TernaryTreeList::Empty
+          FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("deref").into(),
               ns: ns.to_owned(),
@@ -120,7 +120,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
       },
     },
     Cirru::List(ys) => {
-      let mut zs: CalcitItems = TernaryTreeList::Empty;
+      let mut zs: CalcitItems = FingerList::new_empty();
       for y in ys {
         match code_to_calcit(y, ns.to_owned(), def.to_owned()) {
           Ok(v) => {
@@ -142,7 +142,7 @@ pub fn cirru_to_calcit(xs: &Cirru) -> Calcit {
   match xs {
     Cirru::Leaf(s) => Calcit::Str((**s).into()),
     Cirru::List(ys) => {
-      let mut zs: CalcitItems = TernaryTreeList::Empty;
+      let mut zs: CalcitItems = FingerList::new_empty();
       for y in ys {
         zs = zs.push(cirru_to_calcit(y))
       }

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -43,7 +43,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
           Ok(n) => Ok(Calcit::Number(n as f64)),
           Err(e) => Err(format!("failed to parse hex: {} => {:?}", s, e)),
         },
-        '\'' if s.len() > 1 => Ok(Calcit::List(
+        '\'' if s.len() > 1 => Ok(Calcit::List(Arc::new(
           FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("quote").into(),
@@ -57,9 +57,9 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
               at_def: def.to_owned(),
               resolved: None,
             }),
-        )),
+        ))),
         // TODO also detect simple variables
-        '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(
+        '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(Arc::new(
           FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("~@").into(),
@@ -73,8 +73,8 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
               at_def: def.to_owned(),
               resolved: None,
             }),
-        )),
-        '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(
+        ))),
+        '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(Arc::new(
           FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("~").into(),
@@ -88,8 +88,8 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
               at_def: def.to_owned(),
               resolved: None,
             }),
-        )),
-        '@' => Ok(Calcit::List(
+        ))),
+        '@' => Ok(Calcit::List(Arc::new(
           FingerList::new_empty()
             .push(Calcit::Symbol {
               sym: String::from("deref").into(),
@@ -103,7 +103,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
               at_def: def.to_owned(),
               resolved: None,
             }),
-        )),
+        ))),
         // TODO future work of reader literal expanding
         _ => {
           if let Ok(f) = s.parse::<f64>() {
@@ -132,7 +132,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>) -> Result<Calcit,
           Err(e) => return Err(e),
         }
       }
-      Ok(Calcit::List(zs))
+      Ok(Calcit::List(Arc::new(zs)))
     }
   }
 }
@@ -146,7 +146,7 @@ pub fn cirru_to_calcit(xs: &Cirru) -> Calcit {
       for y in ys {
         zs = zs.push(cirru_to_calcit(y))
       }
-      Calcit::List(zs)
+      Calcit::List(Arc::new(zs))
     }
   }
 }
@@ -160,7 +160,7 @@ pub fn calcit_data_to_cirru(xs: &Calcit) -> Result<Cirru, String> {
     Calcit::Str(s) => Ok(Cirru::Leaf((**s).into())),
     Calcit::List(ys) => {
       let mut zs: Vec<Cirru> = Vec::with_capacity(ys.len());
-      for y in ys {
+      for y in &**ys {
         match calcit_data_to_cirru(y) {
           Ok(v) => {
             zs.push(v);
@@ -196,7 +196,7 @@ pub fn calcit_to_cirru(x: &Calcit) -> Result<Cirru, String> {
     Calcit::Keyword(s) => Ok(Cirru::leaf(format!(":{}", s))), // TODO performance
     Calcit::List(xs) => {
       let mut ys: Vec<Cirru> = Vec::with_capacity(xs.len());
-      for x in xs {
+      for x in &**xs {
         ys.push(calcit_to_cirru(x)?);
       }
       Ok(Cirru::List(ys))

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -20,7 +20,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
     Calcit::Symbol { sym, .. } => Ok(Edn::Symbol((**sym).into())),
     Calcit::List(xs) => {
       let mut ys: Vec<Edn> = Vec::with_capacity(xs.len());
-      for x in xs {
+      for x in &**xs {
         ys.push(calcit_to_edn(x)?);
       }
       Ok(Edn::List(ys))
@@ -104,7 +104,7 @@ pub fn edn_to_calcit(x: &Edn) -> Calcit {
       for x in xs {
         ys = ys.push(edn_to_calcit(x))
       }
-      Calcit::List(ys)
+      Calcit::List(Arc::new(ys))
     }
     Edn::Set(xs) => {
       let mut ys: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use crate::data::cirru;
 use crate::primes;
+use crate::primes::finger_list::FingerList;
 use crate::primes::Calcit;
 
 use cirru_edn::{Edn, EdnKwd};
-use im_ternary_tree::TernaryTreeList;
 
 // values does not fit are just represented with specical indicates
 pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
@@ -100,7 +100,7 @@ pub fn edn_to_calcit(x: &Edn) -> Calcit {
     ),
     Edn::Tuple(pair) => Calcit::Tuple(Arc::new(edn_to_calcit(&pair.0)), Arc::new(edn_to_calcit(&pair.1))),
     Edn::List(xs) => {
-      let mut ys: primes::CalcitItems = TernaryTreeList::Empty;
+      let mut ys: primes::CalcitItems = FingerList::new_empty();
       for x in xs {
         ys = ys.push(edn_to_calcit(x))
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub fn load_core_snapshot() -> Result<snapshot::Snapshot, String> {
   let bytes = include_bytes!("./cirru/calcit-core.cirru");
   let core_content = String::from_utf8_lossy(bytes).to_string();
   let core_data = cirru_edn::parse(&core_content)?;
-  snapshot::load_snapshot_data(core_data, "calcit-internal://calcit-core.cirru")
+  snapshot::load_snapshot_data(&core_data, "calcit-internal://calcit-core.cirru")
 }
 
 #[derive(Clone, Debug)]
@@ -115,6 +115,6 @@ pub fn load_module(path: &str, base_dir: &Path) -> Result<snapshot::Snapshot, St
   let content = fs::read_to_string(&fullpath).unwrap_or_else(|_| panic!("expected Cirru snapshot {:?}", fullpath));
   let data = cirru_edn::parse(&content)?;
   // println!("reading: {}", content);
-  let snapshot = snapshot::load_snapshot_data(data, &fullpath)?;
+  let snapshot = snapshot::load_snapshot_data(&data, &fullpath)?;
   Ok(snapshot)
 }

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -1,3 +1,4 @@
+pub mod finger_list;
 mod syntax_name;
 
 use core::cmp::Ord;
@@ -9,14 +10,14 @@ use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 
+use crate::primes::finger_list::FingerList;
 use cirru_edn::EdnKwd;
-use im_ternary_tree::TernaryTreeList;
 
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);
 
 // scope
 pub type CalcitScope = rpds::HashTrieMapSync<Arc<str>, Calcit>;
-pub type CalcitItems = TernaryTreeList<Calcit>;
+pub type CalcitItems = FingerList<Calcit>;
 
 pub use syntax_name::CalcitSyntax;
 
@@ -43,9 +44,9 @@ pub enum ImportRule {
 
 /// special types wraps vector of calcit data for displaying
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
-pub struct CrListWrap(pub TernaryTreeList<Calcit>);
+pub struct CrListWrap(pub FingerList<Calcit>);
 
-pub struct CalcitList(pub Arc<TernaryTreeList<Calcit>>);
+pub struct CalcitList(pub Arc<FingerList<Calcit>>);
 
 #[derive(Debug, Clone)]
 pub enum Calcit {

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -18,10 +18,6 @@ use fingertrees::monoid::Sum;
 
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);
 
-// scope
-pub type CalcitScope = rpds::HashTrieMapSync<Arc<str>, Calcit>;
-pub type CalcitItems = FingerList<Calcit>;
-
 pub use syntax_name::CalcitSyntax;
 
 use crate::call_stack::CallStackList;
@@ -45,11 +41,13 @@ pub enum ImportRule {
   NsDefault(Arc<str>),            // ns, js only
 }
 
+// scope
+pub type CalcitScope = rpds::HashTrieMapSync<Arc<str>, Calcit>;
+pub type CalcitItems = FingerList<Calcit>;
+
 /// special types wraps vector of calcit data for displaying
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CrListWrap(pub FingerList<Calcit>);
-
-pub struct CalcitList(pub Arc<FingerList<Calcit>>);
 
 #[derive(Debug, Clone)]
 pub enum Calcit {

--- a/src/primes/finger_list.rs
+++ b/src/primes/finger_list.rs
@@ -1,0 +1,256 @@
+use std::fmt;
+use std::sync::Arc;
+
+use core::cmp::Ord;
+use std::cmp::Eq;
+use std::cmp::Ordering;
+use std::cmp::Ordering::*;
+use std::fmt::{Debug, Display};
+use std::hash::{Hash, Hasher};
+
+use fingertrees::measure::{Measured, Size};
+use fingertrees::monoid::Sum;
+use std::ops::Index;
+
+use fingertrees::{ArcRefs, FingerTree};
+
+#[derive(Debug, Clone)]
+pub struct FingerList<T>(FingerTree<ArcRefs, Size<Arc<T>>>)
+where
+  T: Clone;
+
+impl<T> fmt::Display for FingerList<T>
+where
+  T: Debug + Clone,
+{
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str("(&filter-list TODO)")
+  }
+}
+
+impl<T> Hash for FingerList<T>
+where
+  T: Debug + Clone + Hash + Ord + Display,
+{
+  fn hash<H>(&self, _state: &mut H)
+  where
+    H: Hasher,
+  {
+    for item in self.iter() {
+      item.hash(_state);
+    }
+  }
+}
+
+impl<T> Ord for FingerList<T>
+where
+  T: Debug + Clone + Hash + Ord + Display,
+{
+  fn cmp(&self, other: &Self) -> Ordering {
+    if self.len() == other.len() {
+      for idx in 0..self.len() {
+        let r = self[idx].cmp(&other[idx]);
+        if r == Equal {
+          continue;
+        } else {
+          return r;
+        }
+      }
+      Equal
+    } else {
+      self.len().cmp(&other.len())
+    }
+  }
+}
+
+impl<T> PartialOrd for FingerList<T>
+where
+  T: Debug + Clone + Ord + Display + Hash,
+{
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl<T> Eq for FingerList<T> where T: Debug + Clone + Ord + Display + Hash {}
+
+impl<T> PartialEq for FingerList<T>
+where
+  T: Debug + Clone + Ord + Display + Hash,
+{
+  fn eq(&self, other: &Self) -> bool {
+    if self.len() == other.len() {
+      for idx in 0..self.len() {
+        if self[idx] != other[idx] {
+          return false;
+        }
+      }
+      true
+    } else {
+      false
+    }
+  }
+}
+
+impl<T> Measured for FingerList<T>
+where
+  T: Debug + Clone,
+{
+  type Measure = Sum<usize>;
+
+  fn measure(&self) -> Self::Measure {
+    Sum(1)
+  }
+}
+
+impl<'a, T> Index<usize> for FingerList<T>
+where
+  T: Clone + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Output = T;
+
+  fn index<'b>(&self, idx: usize) -> &Self::Output {
+    // println!("get: {} {}", self.format_inline(), idx);
+    let (_, right) = self.0.split(|measure| *measure >= Sum(idx));
+    &right.view_left().unwrap().0
+  }
+}
+
+impl<T> FingerList<T>
+where
+  T: Debug + Clone + Ord + Display + Hash,
+{
+  pub fn get(&self, idx: usize) -> Option<&T> {
+    let (_, right) = self.0.split(|measure| *measure >= Sum(idx));
+    Some(&right.view_left().unwrap().0)
+  }
+
+  pub fn len(&self) -> usize {
+    match self.0.measure() {
+      Sum(s) => s,
+    }
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.len() == 0
+  }
+
+  pub fn push(&self, item: T) -> Self {
+    let next = self.0.push_right(Size(Arc::new(item)));
+    Self(next)
+  }
+  pub fn rest(&self) -> Result<Self, String> {
+    let (_, right) = self.0.view_left().unwrap();
+    Ok(Self(right))
+  }
+
+  pub fn butlast(&self) -> Result<Self, String> {
+    let (_, left) = self.0.view_right().unwrap();
+    Ok(Self(left))
+  }
+  pub fn unshift(&self, item: T) -> Self {
+    let next = self.0.push_left(Size(Arc::new(item)));
+    Self(next)
+  }
+  pub fn slice(&self, from: usize, to: usize) -> Result<Self, String> {
+    let (_, right) = self.0.split(|measure| *measure >= Sum(from));
+    let (_, next) = right.split(|measure| *measure >= Sum(to));
+    Ok(Self(next))
+  }
+  pub fn reverse(&self) -> Self {
+    let xs: FingerTree<ArcRefs, Size<Arc<T>>> = FingerTree::new();
+    for y in (&self.0).into_iter() {
+      xs.push_left(y);
+    }
+    Self(xs)
+  }
+
+  pub fn skip(&self, from: usize) -> Result<Self, String> {
+    self.slice(from, self.len() - from)
+  }
+
+  pub fn assoc(&self, from: usize, item: T) -> Result<Self, String> {
+    let (left, right) = self.0.split(|measure| *measure >= Sum(from));
+    let (_, r2) = right.view_left().unwrap();
+    let next = r2.push_left(Size(Arc::new(item)));
+    Ok(Self(left.concat(&next).to_owned()))
+  }
+
+  pub fn dissoc(&self, from: usize) -> Result<Self, String> {
+    let (left, right) = self.0.split(|measure| *measure >= Sum(from));
+    let (_, next) = right.view_right().unwrap();
+    Ok(Self(left.concat(&next).to_owned()))
+  }
+
+  pub fn assoc_before(&self, from: usize, item: T) -> Result<Self, String> {
+    let (left, right) = self.0.split(|measure| *measure >= Sum(from));
+    let next = right.push_left(Size(Arc::new(item)));
+    Ok(Self(left.concat(&next).to_owned()))
+  }
+
+  pub fn assoc_after(&self, from: usize, item: T) -> Result<Self, String> {
+    let (left, right) = self.0.split(|measure| *measure >= Sum(from + 1));
+    let next = right.push_left(Size(Arc::new(item)));
+    Ok(Self(left.concat(&next).to_owned()))
+  }
+
+  pub fn from(xs: &[T]) -> Self {
+    let ret: FingerTree<ArcRefs, _> = xs.iter().map(|x| Size(Arc::new(x.to_owned()))).collect();
+    Self(ret)
+  }
+
+  pub fn new_empty() -> Self {
+    Self(FingerTree::new())
+  }
+
+  pub fn iter(&self) -> FigerListRefIntoIterator<T> {
+    FigerListRefIntoIterator { value: self, index: 0 }
+  }
+
+  pub fn index_of(&self, item: &T) -> Option<usize> {
+    for (idx, y) in (&self.0).into_iter().enumerate() {
+      if item == &**y {
+        return Some(idx);
+      }
+    }
+    None
+  }
+}
+
+// experimental code to turn `&FingerList<_>` into iterator
+impl<'a, T> IntoIterator for &'a FingerList<T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Item = &'a T;
+  type IntoIter = FigerListRefIntoIterator<'a, T>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    FigerListRefIntoIterator { value: self, index: 0 }
+  }
+}
+
+pub struct FigerListRefIntoIterator<'a, T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  value: &'a FingerList<T>,
+  index: usize,
+}
+
+impl<'a, T> Iterator for FigerListRefIntoIterator<'a, T>
+where
+  T: Clone + Display + Eq + PartialEq + Debug + Ord + PartialOrd + Hash,
+{
+  type Item = &'a T;
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.index < self.value.len() {
+      // println!("get: {} {}", self.value.format_inline(), self.index);
+      let idx = self.index;
+      self.index += 1;
+      Some(&self.value[idx])
+    } else {
+      None
+    }
+  }
+}

--- a/src/primes/finger_list.rs
+++ b/src/primes/finger_list.rs
@@ -172,7 +172,8 @@ where
   }
 
   pub fn skip(&self, from: usize) -> Result<Self, String> {
-    self.slice(from, self.len())
+    let (_, right) = self.0.split(|measure| *measure > Sum(from));
+    Ok(Self(right))
   }
 
   pub fn assoc(&self, from: usize, item: T) -> Result<Self, String> {

--- a/src/primes/finger_list.rs
+++ b/src/primes/finger_list.rs
@@ -23,7 +23,7 @@ where
   T: Debug + Clone + Hash + Ord + Display,
 {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.write_str("(&filter-list ")?;
+    f.write_str("(&finger-list ")?;
 
     for x in self.into_iter() {
       f.write_str(" ")?;
@@ -55,7 +55,7 @@ where
   fn cmp(&self, other: &Self) -> Ordering {
     if self.len() == other.len() {
       for idx in 0..self.len() {
-        let r = self.get(idx).cmp(&other.get(idx));
+        let r = self[idx].cmp(&other[idx]);
         if r == Equal {
           continue;
         } else {
@@ -87,7 +87,7 @@ where
   fn eq(&self, other: &Self) -> bool {
     if self.len() == other.len() {
       for idx in 0..self.len() {
-        if self.get(idx) != other.get(idx) {
+        if self[idx] != other[idx] {
           return false;
         }
       }
@@ -211,6 +211,14 @@ where
     Self(FingerTree::new())
   }
 
+  pub fn new2(a: T, b: T) -> Self {
+    Self(FingerTree::new().push_right(Size(a)).push_right(Size(b)))
+  }
+
+  pub fn new3(a: T, b: T, c: T) -> Self {
+    Self(FingerTree::new().push_right(Size(a)).push_right(Size(b)).push_right(Size(c)))
+  }
+
   pub fn iter(&self) -> FigerListRefIntoIterator<T> {
     FigerListRefIntoIterator { value: self, index: 0 }
   }
@@ -256,7 +264,7 @@ where
       // println!("get: {} {}", self.value.format_inline(), self.index);
       let idx = self.index;
       self.index += 1;
-      Some(self.value.get(idx).unwrap())
+      Some(&self.value[idx])
     } else {
       None
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -422,7 +422,7 @@ pub fn evaluate_args(
   file_ns: Arc<str>,
   call_stack: &CallStackList,
 ) -> Result<CalcitItems, CalcitErr> {
-  let mut ret: CalcitItems = FingerList::new_empty();
+  let mut ret: Vec<Calcit> = Vec::with_capacity(items.len());
   let mut spreading = false;
   for item in items {
     match item {
@@ -444,7 +444,7 @@ pub fn evaluate_args(
                   },
                   _ => x.to_owned(),
                 };
-                ret = ret.push(y.to_owned());
+                ret.push(y.to_owned());
               }
               spreading = false
             }
@@ -464,10 +464,10 @@ pub fn evaluate_args(
             },
             _ => v.to_owned(),
           };
-          ret = ret.push(y);
+          ret.push(y);
         }
       }
     }
   }
-  Ok(ret)
+  Ok(FingerList::from(&ret))
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,11 +4,11 @@ pub mod track;
 use crate::builtins;
 use crate::builtins::is_proc_name;
 use crate::call_stack::{extend_call_stack, CallStackList, StackKind};
+use crate::primes::finger_list::FingerList;
 use crate::primes::{Calcit, CalcitErr, CalcitItems, CalcitScope, CalcitSyntax, CrListWrap, SymbolResolved::*, CORE_NS};
 use crate::program;
 use crate::util::string::has_ns_part;
 
-use im_ternary_tree::TernaryTreeList;
 use std::sync::{Arc, RwLock};
 
 pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
@@ -348,7 +348,7 @@ pub fn bind_args(
         "&" => return Err(CalcitErr::use_msg_stack(format!("invalid & in args: {:?}", args), call_stack)),
         "?" => return Err(CalcitErr::use_msg_stack(format!("invalid ? in args: {:?}", args), call_stack)),
         _ => {
-          let mut chunk: CalcitItems = TernaryTreeList::Empty;
+          let mut chunk: CalcitItems = FingerList::new_empty();
           while let Some(v) = values_pop_front() {
             chunk = chunk.push(v.to_owned());
           }
@@ -422,7 +422,7 @@ pub fn evaluate_args(
   file_ns: Arc<str>,
   call_stack: &CallStackList,
 ) -> Result<CalcitItems, CalcitErr> {
-  let mut ret: CalcitItems = TernaryTreeList::Empty;
+  let mut ret: CalcitItems = FingerList::new_empty();
   let mut spreading = false;
   for item in items {
     match item {

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -2,6 +2,7 @@ use crate::{
   builtins::{is_js_syntax_procs, is_proc_name},
   call_stack::{extend_call_stack, CalcitStack, CallStackList, StackKind},
   primes,
+  primes::finger_list::FingerList,
   primes::{Calcit, CalcitErr, CalcitItems, CalcitSyntax, ImportRule, SymbolResolved::*},
   program, runner,
 };
@@ -9,8 +10,6 @@ use crate::{
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::sync::Arc;
-
-use im_ternary_tree::TernaryTreeList;
 
 /// returns the resolved symbol,
 /// if code related is not preprocessed, do it internally
@@ -57,7 +56,7 @@ pub fn preprocess_ns_def(
             def.to_owned(),
             StackKind::Fn,
             code.to_owned(),
-            &TernaryTreeList::Empty,
+            &FingerList::new_empty(),
           );
 
           let (resolved_code, _resolve_value) = preprocess_expr(&code, &HashSet::new(), ns.to_owned(), check_warnings, &next_stack)?;
@@ -315,7 +314,7 @@ fn process_list_call(
   match (head_form.to_owned(), head_evaled) {
     (Calcit::Keyword(..), _) => {
       if args.len() == 1 {
-        let code = Calcit::List(TernaryTreeList::from(&[
+        let code = Calcit::List(FingerList::from(&[
           Calcit::Symbol {
             sym: String::from("get").into(),
             ns: String::from(primes::CORE_NS).into(),
@@ -429,7 +428,7 @@ fn process_list_call(
         let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
         ys.push(form);
       }
-      Ok((Calcit::List(TernaryTreeList::from(ys)), None))
+      Ok((Calcit::List(FingerList::from(&ys)), None))
     }
     (_, _) => {
       let mut ys = Vec::with_capacity(args.len() + 1);
@@ -438,7 +437,7 @@ fn process_list_call(
         let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
         ys.push(form);
       }
-      Ok((Calcit::List(TernaryTreeList::from(ys)), None))
+      Ok((Calcit::List(FingerList::from(&ys)), None))
     }
   }
 }
@@ -533,7 +532,7 @@ pub fn preprocess_each_items(
   check_warnings: &RefCell<Vec<String>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   for a in args {
     let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
     xs = xs.push(form);
@@ -551,7 +550,7 @@ pub fn preprocess_defn(
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
   // println!("defn args: {}", primes::CrListWrap(args.to_owned()));
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   match (args.get(0), args.get(1)) {
     (
       Some(Calcit::Symbol {
@@ -570,7 +569,7 @@ pub fn preprocess_defn(
         at_def: at_def.to_owned(),
         resolved: Some(Arc::new(ResolvedRaw)),
       });
-      let mut zs: CalcitItems = TernaryTreeList::Empty;
+      let mut zs: CalcitItems = FingerList::new_empty();
       for y in ys {
         match y {
           Calcit::Symbol {
@@ -639,7 +638,7 @@ pub fn preprocess_call_let(
   check_warnings: &RefCell<Vec<String>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   let mut body_defs: HashSet<Arc<str>> = scope_defs.to_owned();
   let binding = match args.get(0) {
     Some(Calcit::Nil) => Calcit::Nil,
@@ -648,7 +647,7 @@ pub fn preprocess_call_let(
         check_symbol(sym, args, check_warnings);
         body_defs.insert(sym.to_owned());
         let (form, _v) = preprocess_expr(a, &body_defs, file_ns.to_owned(), check_warnings, call_stack)?;
-        Calcit::List(TernaryTreeList::from(&[ys[0].to_owned(), form]))
+        Calcit::List(FingerList::from(&[ys[0].to_owned(), form]))
       }
       (a, b) => {
         return Err(CalcitErr::use_msg_stack(
@@ -693,7 +692,7 @@ pub fn preprocess_quote(
   _scope_defs: &HashSet<Arc<str>>,
   _file_ns: Arc<str>,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   for a in args {
     xs = xs.push(a.to_owned());
   }
@@ -709,7 +708,7 @@ pub fn preprocess_defatom(
   check_warnings: &RefCell<Vec<String>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   for a in args {
     // TODO
     let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
@@ -728,7 +727,7 @@ pub fn preprocess_quasiquote(
   check_warnings: &RefCell<Vec<String>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = FingerList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
   for a in args {
     xs = xs.push(preprocess_quasiquote_internal(
       a,
@@ -752,7 +751,7 @@ pub fn preprocess_quasiquote_internal(
     Calcit::List(ys) if ys.is_empty() => Ok(x.to_owned()),
     Calcit::List(ys) => match &ys[0] {
       Calcit::Symbol { sym, .. } if &**sym == "~" || &**sym == "~@" => {
-        let mut xs: CalcitItems = TernaryTreeList::Empty;
+        let mut xs: CalcitItems = FingerList::new_empty();
         for y in ys {
           let (form, _) = preprocess_expr(y, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
           xs = xs.push(form.to_owned());
@@ -760,7 +759,7 @@ pub fn preprocess_quasiquote_internal(
         Ok(Calcit::List(xs))
       }
       _ => {
-        let mut xs: CalcitItems = TernaryTreeList::Empty;
+        let mut xs: CalcitItems = FingerList::new_empty();
         for y in ys {
           xs = xs.push(preprocess_quasiquote_internal(y, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?.to_owned());
         }


### PR DESCRIPTION
No doubt that finger tree has a better performance https://gist.github.com/jiyinyiyong/c5a9231e9d0e57060c302caac9a7bf86 . (Also it's a data structure that Haskell community proved to be able to be performant https://github.com/haskell-perf/sequences#results) .

Current implementation is slower in running default test,

```
167.32ms
181.128ms
188.221ms
189.993ms
179.551ms
194.768ms
186.948ms
180.29ms
174.392ms
203.554ms
```

compared to the result with ternary-tree:

```
165.206ms
177.051ms
197.866ms
181.556ms
195.387ms
199.398ms
178.274ms
173.925ms
175.909ms
186.421ms
```

partly caused by `Arc`. Profiling indicates that too much `Calcit` `Clone` happened after finger tree used. hope it become cheaper. Overall, finger tree is supposed to be more reliable than an unbalanced 2-3 tree.


