### PR TITLE
add function &format-ternary-tree

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -39,6 +39,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "turn-keyword"
       | "&compare"
       | "&get-os"
+      | "&list-format-inline"
       // tuples
       | "::" // unstable
       | "&tuple:nth"
@@ -222,6 +223,7 @@ fn handle_proc_internal(name: &str, args: &CalcitItems, call_stack: &CallStackLi
     "turn-keyword" => meta::turn_keyword(args),
     "&compare" => meta::native_compare(args),
     "&get-os" => meta::get_os(args),
+    "&format-ternary-tree" => meta::format_ternary_tree(args),
     // tuple
     "::" => meta::new_tuple(args), // unstable solution for the name
     "&tuple:nth" => meta::tuple_nth(args),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -412,3 +412,13 @@ pub fn async_sleep(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calci
 
   Ok(Calcit::Nil)
 }
+
+pub fn format_ternary_tree(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
+  if xs.len() != 1 {
+    return CalcitErr::err_str(format!("&format-ternary-tree expected 1 argument, got: {:?}", xs));
+  }
+  match &xs[0] {
+    Calcit::List(ys) => Ok(Calcit::Str(ys.format_inline().into())),
+    a => CalcitErr::err_str(format!("&format-ternary-tree expected a list, got: {}", a)),
+  }
+}


### PR DESCRIPTION
which displays internal structure of lists inside `im_ternary_tree`.